### PR TITLE
fix: improve mobile Chronicles bottom nav spacing and add scroll-hide…

### DIFF
--- a/src/components/social/SocialBottomNav.tsx
+++ b/src/components/social/SocialBottomNav.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { Ellipsis } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import {
   Sheet,
   SheetClose,
@@ -23,33 +24,39 @@ function BottomNavItem({ item }: { item: SocialNavItem }) {
       end={item.end}
       className={({ isActive }) =>
         cn(
-          "flex flex-col items-center gap-1 rounded-lg px-2 py-1 text-[11px] transition-colors",
+          "flex flex-col items-center gap-1 rounded-lg px-2 py-1.5 text-xs transition-colors",
           isActive
             ? "text-foreground"
             : "text-muted-foreground hover:text-foreground"
         )
       }
     >
-      <item.icon className="h-5 w-5" />
+      <item.icon className="h-[22px] w-[22px]" />
       <span>{item.label}</span>
     </NavLink>
   );
 }
 
-export function SocialBottomNav() {
+interface SocialBottomNavProps {
+  isVisible?: boolean;
+}
+
+export function SocialBottomNav({ isVisible = true }: SocialBottomNavProps) {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
-    <nav
+    <motion.nav
       className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/95 px-3 pb-[max(env(safe-area-inset-bottom),0.4rem)] pt-1.5 backdrop-blur md:hidden"
       aria-label="Mobile social navigation"
+      animate={{ y: isVisible ? 0 : "100%" }}
+      transition={{
+        type: "tween",
+        duration: prefersReducedMotion ? 0 : 0.3,
+        ease: [0.25, 0.1, 0.25, 1],
+      }}
     >
-      <div className="mx-auto grid max-w-xl grid-cols-6 items-end">
-        {socialBottomPrimaryNav.slice(0, 2).map((item) => (
-          <BottomNavItem key={item.id} item={item} />
-        ))}
-
-        <div className="flex justify-center" />
-
-        {socialBottomPrimaryNav.slice(2).map((item) => (
+      <div className="mx-auto grid max-w-xl grid-cols-5 items-end">
+        {socialBottomPrimaryNav.map((item) => (
           <BottomNavItem key={item.id} item={item} />
         ))}
 
@@ -57,10 +64,10 @@ export function SocialBottomNav() {
           <SheetTrigger asChild>
             <button
               type="button"
-              className="flex flex-col items-center gap-1 rounded-lg px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+              className="flex flex-col items-center gap-1 rounded-lg px-2 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
               aria-label="More navigation items"
             >
-              <Ellipsis className="h-5 w-5" />
+              <Ellipsis className="h-[22px] w-[22px]" />
               <span>More</span>
             </button>
           </SheetTrigger>
@@ -93,6 +100,6 @@ export function SocialBottomNav() {
           </SheetContent>
         </Sheet>
       </div>
-    </nav>
+    </motion.nav>
   );
 }

--- a/src/components/social/SocialComposeButton.tsx
+++ b/src/components/social/SocialComposeButton.tsx
@@ -1,20 +1,34 @@
 import { PenSquare } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
 import { Button } from "@/components/ui/button";
 
 interface SocialComposeButtonProps {
   onClick: () => void;
+  navVisible?: boolean;
 }
 
-export function SocialComposeButton({ onClick }: SocialComposeButtonProps) {
+export function SocialComposeButton({ onClick, navVisible = true }: SocialComposeButtonProps) {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
-    <Button
-      type="button"
-      onClick={onClick}
-      size="icon-lg"
-      className="fixed bottom-20 right-4 z-40 rounded-full bg-accent text-accent-foreground shadow-lg hover:bg-accent/90 md:hidden"
-      aria-label="Compose chronicle"
+    <motion.div
+      className="fixed bottom-20 right-4 z-40 md:hidden"
+      animate={{ y: navVisible ? 0 : 60 }}
+      transition={{
+        type: "tween",
+        duration: prefersReducedMotion ? 0 : 0.3,
+        ease: [0.25, 0.1, 0.25, 1],
+      }}
     >
-      <PenSquare className="h-5 w-5" />
-    </Button>
+      <Button
+        type="button"
+        onClick={onClick}
+        size="icon-lg"
+        className="rounded-full bg-accent text-accent-foreground shadow-lg hover:bg-accent/90"
+        aria-label="Compose chronicle"
+      >
+        <PenSquare className="h-5 w-5" />
+      </Button>
+    </motion.div>
   );
 }

--- a/src/components/social/SocialLayout.tsx
+++ b/src/components/social/SocialLayout.tsx
@@ -7,6 +7,7 @@ interface SocialLayoutProps {
   rightRail?: ReactNode;
   navCounts: Partial<Record<string, number>>;
   onComposeClick: () => void;
+  navVisible?: boolean;
 }
 
 export function SocialLayout({
@@ -14,6 +15,7 @@ export function SocialLayout({
   rightRail,
   navCounts,
   onComposeClick,
+  navVisible,
 }: SocialLayoutProps) {
   return (
     <div className="min-h-screen bg-background">
@@ -27,7 +29,7 @@ export function SocialLayout({
         {rightRail}
       </div>
 
-      <SocialBottomNav />
+      <SocialBottomNav isVisible={navVisible} />
     </div>
   );
 }

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseScrollDirectionOptions {
+  threshold?: number;
+}
+
+export function useScrollDirection({ threshold = 10 }: UseScrollDirectionOptions = {}) {
+  const [isVisible, setIsVisible] = useState(true);
+  const lastScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    function update() {
+      const currentY = window.scrollY;
+
+      if (currentY <= 0) {
+        setIsVisible(true);
+      } else if (Math.abs(currentY - lastScrollY.current) >= threshold) {
+        setIsVisible(currentY < lastScrollY.current);
+        lastScrollY.current = currentY;
+      }
+
+      ticking.current = false;
+    }
+
+    function onScroll() {
+      if (!ticking.current) {
+        requestAnimationFrame(update);
+        ticking.current = true;
+      }
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+
+  return isVisible;
+}

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/data/mockDiscovery";
 import { useLibrary } from "@/hooks/useIndexedDB";
 import { useRouteScrollRestoration } from "@/hooks/useRouteScrollRestoration";
+import { useScrollDirection } from "@/hooks/useScrollDirection";
 import { FeedHeader } from "@/components/social/FeedHeader";
 import { ChronicleComposer } from "@/components/social/ChronicleComposer";
 import { FeedTimeline } from "@/components/social/FeedTimeline";
@@ -94,6 +95,8 @@ export default function Feed() {
 
   // Real books from IndexedDB for current user
   const { books: libraryBooks } = useLibrary();
+
+  const navVisible = useScrollDirection({ threshold: 10 });
 
   useRouteScrollRestoration(location.pathname);
 
@@ -350,6 +353,7 @@ export default function Feed() {
       <SocialLayout
         navCounts={navCounts}
         onComposeClick={() => setComposeOpen(true)}
+        navVisible={navVisible}
         rightRail={
           <FeedRightRail
             trending={trendingBooks}
@@ -425,7 +429,9 @@ export default function Feed() {
         />
       </SocialLayout>
 
-      {showComposeButton && <SocialComposeButton onClick={() => setComposeOpen(true)} />}
+      {showComposeButton && (
+        <SocialComposeButton onClick={() => setComposeOpen(true)} navVisible={navVisible} />
+      )}
 
       <Dialog open={composeOpen} onOpenChange={setComposeOpen}>
         <DialogContent className="max-w-xl p-0">


### PR DESCRIPTION
… animation

Rework the bottom nav grid from 6 to 5 columns, removing the empty center gap for balanced spacing. Increase touch targets and icon sizes. Add scroll-direction-aware hide/show animation to the bottom nav and compose FAB using motion/react, with reduced-motion support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth animations to the navigation bar and compose button that respond to scroll direction
  * Navigation automatically hides when scrolling down and reappears when scrolling up for improved space utilization
  * Expanded "More" menu with additional navigation options

* **Improvements**
  * Enhanced navigation item spacing and icon sizing for better visibility
  * Added support for reduced-motion accessibility preferences to respect user preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->