### PR TITLE
feat: replace binary nav hide/show with X-style finger-tracking scrol…

### DIFF
--- a/src/components/social/SocialBottomNav.tsx
+++ b/src/components/social/SocialBottomNav.tsx
@@ -1,6 +1,6 @@
+import { type RefObject } from "react";
 import { NavLink } from "react-router-dom";
 import { Ellipsis } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
 import {
   Sheet,
   SheetClose,
@@ -38,22 +38,17 @@ function BottomNavItem({ item }: { item: SocialNavItem }) {
 }
 
 interface SocialBottomNavProps {
-  isVisible?: boolean;
+  navOffset?: number;
+  navRef?: RefObject<HTMLElement | null>;
 }
 
-export function SocialBottomNav({ isVisible = true }: SocialBottomNavProps) {
-  const prefersReducedMotion = useReducedMotion();
-
+export function SocialBottomNav({ navOffset = 0, navRef }: SocialBottomNavProps) {
   return (
-    <motion.nav
-      className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/95 px-3 pb-[max(env(safe-area-inset-bottom),0.4rem)] pt-1.5 backdrop-blur md:hidden"
+    <nav
+      ref={navRef}
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/95 px-3 pb-[max(env(safe-area-inset-bottom),0.4rem)] pt-1.5 backdrop-blur will-change-transform md:hidden"
       aria-label="Mobile social navigation"
-      animate={{ y: isVisible ? 0 : "100%" }}
-      transition={{
-        type: "tween",
-        duration: prefersReducedMotion ? 0 : 0.3,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+      style={{ transform: `translateY(${navOffset}px)` }}
     >
       <div className="mx-auto grid max-w-xl grid-cols-5 items-end">
         {socialBottomPrimaryNav.map((item) => (
@@ -100,6 +95,6 @@ export function SocialBottomNav({ isVisible = true }: SocialBottomNavProps) {
           </SheetContent>
         </Sheet>
       </div>
-    </motion.nav>
+    </nav>
   );
 }

--- a/src/components/social/SocialComposeButton.tsx
+++ b/src/components/social/SocialComposeButton.tsx
@@ -1,24 +1,16 @@
 import { PenSquare } from "lucide-react";
-import { motion, useReducedMotion } from "motion/react";
 import { Button } from "@/components/ui/button";
 
 interface SocialComposeButtonProps {
   onClick: () => void;
-  navVisible?: boolean;
+  navOffset?: number;
 }
 
-export function SocialComposeButton({ onClick, navVisible = true }: SocialComposeButtonProps) {
-  const prefersReducedMotion = useReducedMotion();
-
+export function SocialComposeButton({ onClick, navOffset = 0 }: SocialComposeButtonProps) {
   return (
-    <motion.div
-      className="fixed bottom-20 right-4 z-40 md:hidden"
-      animate={{ y: navVisible ? 0 : 60 }}
-      transition={{
-        type: "tween",
-        duration: prefersReducedMotion ? 0 : 0.3,
-        ease: [0.25, 0.1, 0.25, 1],
-      }}
+    <div
+      className="fixed bottom-20 right-4 z-40 will-change-transform md:hidden"
+      style={{ transform: `translateY(${navOffset}px)` }}
     >
       <Button
         type="button"
@@ -29,6 +21,6 @@ export function SocialComposeButton({ onClick, navVisible = true }: SocialCompos
       >
         <PenSquare className="h-5 w-5" />
       </Button>
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/social/SocialLayout.tsx
+++ b/src/components/social/SocialLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 import { SocialBottomNav } from "./SocialBottomNav";
 import { SocialSidebar } from "./SocialSidebar";
 
@@ -7,7 +7,8 @@ interface SocialLayoutProps {
   rightRail?: ReactNode;
   navCounts: Partial<Record<string, number>>;
   onComposeClick: () => void;
-  navVisible?: boolean;
+  navOffset?: number;
+  navRef?: RefObject<HTMLElement | null>;
 }
 
 export function SocialLayout({
@@ -15,7 +16,8 @@ export function SocialLayout({
   rightRail,
   navCounts,
   onComposeClick,
-  navVisible,
+  navOffset,
+  navRef,
 }: SocialLayoutProps) {
   return (
     <div className="min-h-screen bg-background">
@@ -29,7 +31,7 @@ export function SocialLayout({
         {rightRail}
       </div>
 
-      <SocialBottomNav isVisible={navVisible} />
+      <SocialBottomNav navOffset={navOffset} navRef={navRef} />
     </div>
   );
 }

--- a/src/hooks/useScrollDirection.ts
+++ b/src/hooks/useScrollDirection.ts
@@ -1,25 +1,90 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 
-interface UseScrollDirectionOptions {
-  threshold?: number;
+interface UseScrollDirectionResult {
+  offset: number;
+  navRef: RefObject<HTMLElement | null>;
 }
 
-export function useScrollDirection({ threshold = 10 }: UseScrollDirectionOptions = {}) {
-  const [isVisible, setIsVisible] = useState(true);
-  const lastScrollY = useRef(0);
+export function useScrollDirection(): UseScrollDirectionResult {
+  const navRef = useRef<HTMLElement | null>(null);
+  const offsetRef = useRef(0);
+  const prevScrollY = useRef(0);
   const ticking = useRef(false);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snapRaf = useRef<number | null>(null);
+
+  // We store a setter callback so we can force re-render only when offset changes meaningfully
+  const forceUpdate = useForceUpdate();
+
+  const getNavHeight = useCallback(() => {
+    if (!navRef.current) return 60; // sensible default
+    return navRef.current.getBoundingClientRect().height;
+  }, []);
 
   useEffect(() => {
-    function update() {
-      const currentY = window.scrollY;
+    function snapToNearest() {
+      const navHeight = getNavHeight();
+      const current = offsetRef.current;
+      if (current <= 0 || current >= navHeight) return;
 
-      if (currentY <= 0) {
-        setIsVisible(true);
-      } else if (Math.abs(currentY - lastScrollY.current) >= threshold) {
-        setIsVisible(currentY < lastScrollY.current);
-        lastScrollY.current = currentY;
+      const target = current < navHeight / 2 ? 0 : navHeight;
+      const startOffset = current;
+      const startTime = performance.now();
+      const duration = 150;
+
+      function animate(now: number) {
+        const elapsed = now - startTime;
+        const t = Math.min(elapsed / duration, 1);
+        // ease-out quad
+        const eased = t * (2 - t);
+        offsetRef.current = startOffset + (target - startOffset) * eased;
+        forceUpdate();
+
+        if (t < 1) {
+          snapRaf.current = requestAnimationFrame(animate);
+        } else {
+          offsetRef.current = target;
+          forceUpdate();
+          snapRaf.current = null;
+        }
       }
 
+      if (snapRaf.current !== null) {
+        cancelAnimationFrame(snapRaf.current);
+      }
+      snapRaf.current = requestAnimationFrame(animate);
+    }
+
+    function scheduleSnap() {
+      if (idleTimer.current !== null) {
+        clearTimeout(idleTimer.current);
+      }
+      idleTimer.current = setTimeout(() => {
+        snapToNearest();
+        idleTimer.current = null;
+      }, 100);
+    }
+
+    function update() {
+      const currentY = window.scrollY;
+      const delta = currentY - prevScrollY.current;
+      prevScrollY.current = currentY;
+
+      // Cancel any ongoing snap when user scrolls again
+      if (snapRaf.current !== null) {
+        cancelAnimationFrame(snapRaf.current);
+        snapRaf.current = null;
+      }
+
+      if (currentY <= 0) {
+        offsetRef.current = 0;
+      } else {
+        const navHeight = getNavHeight();
+        offsetRef.current = Math.min(Math.max(offsetRef.current + delta, 0), navHeight);
+      }
+
+      forceUpdate();
+      scheduleSnap();
       ticking.current = false;
     }
 
@@ -30,9 +95,25 @@ export function useScrollDirection({ threshold = 10 }: UseScrollDirectionOptions
       }
     }
 
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, [threshold]);
+    prevScrollY.current = window.scrollY;
 
-  return isVisible;
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (idleTimer.current !== null) clearTimeout(idleTimer.current);
+      if (snapRaf.current !== null) cancelAnimationFrame(snapRaf.current);
+    };
+  }, [getNavHeight, forceUpdate]);
+
+  return { offset: offsetRef.current, navRef };
+}
+
+/** Minimal force-update hook that returns a stable callback */
+function useForceUpdate(): () => void {
+  const ref = useRef(0);
+  const [, setState] = useState(0);
+  return useCallback(() => {
+    ref.current += 1;
+    setState(ref.current);
+  }, []);
 }

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -96,7 +96,7 @@ export default function Feed() {
   // Real books from IndexedDB for current user
   const { books: libraryBooks } = useLibrary();
 
-  const navVisible = useScrollDirection({ threshold: 10 });
+  const { offset: navOffset, navRef } = useScrollDirection();
 
   useRouteScrollRestoration(location.pathname);
 
@@ -353,7 +353,8 @@ export default function Feed() {
       <SocialLayout
         navCounts={navCounts}
         onComposeClick={() => setComposeOpen(true)}
-        navVisible={navVisible}
+        navOffset={navOffset}
+        navRef={navRef}
         rightRail={
           <FeedRightRail
             trending={trendingBooks}
@@ -430,7 +431,7 @@ export default function Feed() {
       </SocialLayout>
 
       {showComposeButton && (
-        <SocialComposeButton onClick={() => setComposeOpen(true)} navVisible={navVisible} />
+        <SocialComposeButton onClick={() => setComposeOpen(true)} navOffset={navOffset} />
       )}
 
       <Dialog open={composeOpen} onOpenChange={setComposeOpen}>


### PR DESCRIPTION
Adding Finger-tracking to use the pixel-by-pixel scroll delta to clam up or down the bottom navigation header for the mobile view of the Chronicles Social Media feed. 

Replace the boolean isVisible toggle with a continuous pixel offset that tracks scroll delta 1:1, giving the bottom nav and FAB a fluid, finger-following feel. Nav snaps to nearest state after 100ms idle via RAF lerp. Drops motion/react dependency from both components in favor of lightweight inline transforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation now positions dynamically based on scroll direction with intelligent snapping behavior when scrolling stops.

* **Performance**
  * Improved rendering efficiency by switching from animation-based to transform-based positioning for navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->