### PR TITLE
Fix native text selection UX in epub iframe

### DIFF
--- a/src/lib/theme/readingThemes.ts
+++ b/src/lib/theme/readingThemes.ts
@@ -66,7 +66,7 @@ export function getThemeCSS(
       "-webkit-user-select": "text !important",
       "-moz-user-select": "text !important",
     },
-    "body::selection, body *::selection": {
+    "::selection": {
       "background-color": config.selectionBg,
     },
     "a, a:link, a:visited": {


### PR DESCRIPTION
## Summary

- Eliminates the red tap-highlight flash that appears when touching/hovering text before a click registers (`-webkit-tap-highlight-color: transparent` on `body`)
- Replaces the OS default (red) selection color with each theme's warm accent color at 25–30% opacity via a `::selection` rule
- Ensures native OS selection handles (teardrops on iOS, circles on Android) work by explicitly setting `user-select: text` / `-webkit-user-select: text`, which wins over any epub stylesheet that may suppress selection

## Files changed

| File | Change |
|------|--------|
| `src/lib/theme/readingThemes.ts` | Added `selectionBg` to `ThemeConfig` and all four themes; updated `getThemeCSS()` with tap-highlight, user-select, and `::selection` overrides |

## Test plan

- [ ] Open a book → hover/touch text → no red flash before clicking
- [ ] Long-press a word → native OS teardrop handles appear, selection is warm amber (Paper) not red
- [ ] Drag a handle to extend selection → selection adjusts normally, no full-page selection
- [ ] Switch to Night theme → selection is warm gold, visible on dark background
- [ ] Switch to Focus / Sepia → selection colour matches theme accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable text-selection backgrounds available across all reading themes for a more personalized look
  * Theme-specific selection styling for clearer visual feedback when highlighting text
  * Improved touch and selection behavior (refined tap-highlight and selection handling) for better mobile interaction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->