### PR TITLE
feat: add Spotify mood-based reading music integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Spotify API credentials (get from https://developer.spotify.com/dashboard)
+# Only the client ID is needed — PKCE flow doesn't require a secret
+VITE_SPOTIFY_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+/docs/
+
+# Environment variables
+.env
+.env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,9 @@
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/src/components/reader/SpotifyMoodPlayer.tsx
+++ b/src/components/reader/SpotifyMoodPlayer.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Music, X, SkipForward, SkipBack } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSpotifyEmbed } from '@/hooks/useSpotifyEmbed';
+import { useSpotifyMood } from '@/hooks/useSpotifyMood';
+import { READING_MOODS, type ReadingMood } from '@/lib/spotify/moods';
+import type { BookSettings } from '@/types/book';
+
+interface SpotifyMoodPlayerProps {
+  settings: BookSettings | null;
+  saveSettings: (partial: Partial<BookSettings>) => Promise<void>;
+}
+
+export function SpotifyMoodPlayer({ settings, saveSettings }: SpotifyMoodPlayerProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const embedDivRef = useRef<HTMLDivElement | null>(null);
+  const [embedEl, setEmbedEl] = useState<HTMLDivElement | null>(null);
+  const [trackIndex, setTrackIndex] = useState(0);
+  const { selectedMood, setMood, tracks, loading, error, isAuthenticated, connectSpotify } =
+    useSpotifyMood(settings, saveSettings);
+
+  const trackIndexRef = useRef(trackIndex);
+  trackIndexRef.current = trackIndex;
+  const tracksRef = useRef(tracks);
+  tracksRef.current = tracks;
+  const loadUriRef = useRef<((uri: string) => void) | undefined>(undefined);
+
+  const advanceTrack = useCallback(() => {
+    if (tracksRef.current.length === 0) return;
+    const next = (trackIndexRef.current + 1) % tracksRef.current.length;
+    setTrackIndex(next);
+    loadUriRef.current?.(tracksRef.current[next].uri);
+  }, []);
+
+  const { isReady, loadUri } = useSpotifyEmbed(embedEl, advanceTrack);
+  loadUriRef.current = loadUri;
+
+  const attachEmbed = useCallback((wrapper: HTMLDivElement | null) => {
+    if (!wrapper) return;
+    if (!embedDivRef.current) {
+      const div = document.createElement('div');
+      div.style.height = '152px';
+      div.style.width = '100%';
+      div.style.borderRadius = '0.25rem';
+      div.style.border = '1px solid var(--border, #e5e7eb)';
+      embedDivRef.current = div;
+      setEmbedEl(div);
+    }
+    if (!wrapper.contains(embedDivRef.current)) {
+      wrapper.appendChild(embedDivRef.current);
+    }
+  }, []);
+
+  // Single effect for loading tracks — handles both new mood and embed ready
+  useEffect(() => {
+    if (tracks.length > 0 && isReady) {
+      const idx = Math.floor(Math.random() * tracks.length);
+      setTrackIndex(idx);
+      loadUri(tracks[idx].uri);
+    }
+  }, [tracks, isReady, loadUri]);
+
+  const prevTrack = useCallback(() => {
+    if (tracks.length === 0) return;
+    const prev = (trackIndex - 1 + tracks.length) % tracks.length;
+    setTrackIndex(prev);
+    loadUri(tracks[prev].uri);
+  }, [tracks, trackIndex, loadUri]);
+
+  const nextTrack = useCallback(() => {
+    if (tracks.length === 0) return;
+    const next = (trackIndex + 1) % tracks.length;
+    setTrackIndex(next);
+    loadUri(tracks[next].uri);
+  }, [tracks, trackIndex, loadUri]);
+
+  return (
+    <>
+      {!isExpanded && (
+        <Button
+          onClick={() => setIsExpanded(true)}
+          size="sm"
+          variant="outline"
+          className="fixed bottom-4 right-4 z-40 h-10 w-10 rounded-full p-0 backdrop-blur-md reading-surface border"
+        >
+          <Music className="h-4 w-4" />
+        </Button>
+      )}
+
+      <div
+        className={`fixed bottom-4 right-4 z-40 w-80 reading-surface backdrop-blur-md border rounded-lg shadow-lg p-4 transition-all duration-200 ${
+          isExpanded ? 'opacity-100 scale-100' : 'opacity-0 scale-95 pointer-events-none'
+        }`}
+      >
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-medium">Reading Mood</h3>
+          <div className="flex items-center gap-1">
+            {tracks.length > 0 && (
+              <>
+                <Button
+                  onClick={prevTrack}
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 w-6 p-0"
+                  title="Previous track"
+                >
+                  <SkipBack className="h-3 w-3" />
+                </Button>
+                <Button
+                  onClick={nextTrack}
+                  size="sm"
+                  variant="ghost"
+                  className="h-6 w-6 p-0"
+                  title="Next track"
+                >
+                  <SkipForward className="h-3 w-3" />
+                </Button>
+              </>
+            )}
+            <Button
+              onClick={() => setIsExpanded(false)}
+              size="sm"
+              variant="ghost"
+              className="h-6 w-6 p-0"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        </div>
+
+        {!isAuthenticated ? (
+          <div className="text-center py-4">
+            <p className="text-xs text-muted-foreground mb-3">
+              Connect your Spotify account to play reading music
+            </p>
+            <Button onClick={connectSpotify} size="sm" className="text-xs">
+              Connect Spotify
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="flex gap-2 overflow-x-auto pb-2 mb-3 scrollbar-hide">
+              {Object.entries(READING_MOODS).map(([key, mood]) => (
+                <Button
+                  key={key}
+                  onClick={() => setMood(key as ReadingMood)}
+                  size="sm"
+                  variant={selectedMood === key ? "default" : "outline"}
+                  className="flex-shrink-0 text-xs px-3 py-1 h-auto"
+                >
+                  <span className="mr-1">{mood.emoji}</span>
+                  {mood.label}
+                </Button>
+              ))}
+              {selectedMood && (
+                <Button
+                  onClick={() => setMood(null)}
+                  size="sm"
+                  variant="ghost"
+                  className="flex-shrink-0 text-xs px-2 py-1 h-auto"
+                >
+                  Clear
+                </Button>
+              )}
+            </div>
+
+            {loading && (
+              <div className="text-xs text-muted-foreground mb-2">Loading tracks...</div>
+            )}
+
+            {error && (
+              <div className="text-xs text-red-500 mb-2">{error}</div>
+            )}
+
+            <div ref={attachEmbed} />
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useBookSettings.ts
+++ b/src/hooks/useBookSettings.ts
@@ -4,6 +4,7 @@ import type { BookSettings } from "@/types/book";
 
 const DEFAULT_SETTINGS = {
   disableBottomScrubber: false,
+  spotifyMood: null as string | null,
 };
 
 export function useBookSettings(bookHash: string | null) {
@@ -37,7 +38,7 @@ export function useBookSettings(bookHash: string | null) {
         } else {
           setSettings({
             bookHash,
-            disableBottomScrubber: DEFAULT_SETTINGS.disableBottomScrubber,
+            ...DEFAULT_SETTINGS,
             updatedAt: Date.now(),
           });
         }
@@ -46,7 +47,7 @@ export function useBookSettings(bookHash: string | null) {
         if (cancelled) return;
         setSettings({
           bookHash,
-          disableBottomScrubber: DEFAULT_SETTINGS.disableBottomScrubber,
+          ...DEFAULT_SETTINGS,
           updatedAt: Date.now(),
         });
       })
@@ -66,7 +67,7 @@ export function useBookSettings(bookHash: string | null) {
       if (!bookHash) return;
       const base = settingsRef.current ?? {
         bookHash,
-        disableBottomScrubber: DEFAULT_SETTINGS.disableBottomScrubber,
+        ...DEFAULT_SETTINGS,
         updatedAt: Date.now(),
       };
       const merged: BookSettings = {

--- a/src/hooks/useSpotifyEmbed.ts
+++ b/src/hooks/useSpotifyEmbed.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+
+interface PlaybackUpdate {
+  data: { isPaused: boolean; position: number; duration: number };
+}
+
+interface SpotifyController {
+  loadUri: (uri: string) => void;
+  play: () => void;
+  togglePlay: () => void;
+  destroy: () => void;
+  addListener: (event: string, cb: (e: PlaybackUpdate) => void) => void;
+}
+
+interface SpotifyIFrameAPI {
+  createController: (
+    element: HTMLElement,
+    options: { uri?: string; width: string; height: number; theme?: string },
+    callback: (controller: SpotifyController) => void
+  ) => void;
+}
+
+declare global {
+  interface Window {
+    onSpotifyIframeApiReady?: (api: SpotifyIFrameAPI) => void;
+    _spotifyIFrameAPI?: SpotifyIFrameAPI;
+  }
+}
+
+function loadSpotifyScript() {
+  if (document.querySelector('script[src*="spotify.com/embed"]') || window._spotifyIFrameAPI) return;
+  const script = document.createElement('script');
+  script.src = 'https://open.spotify.com/embed/iframe-api/v1';
+  script.async = true;
+  document.head.appendChild(script);
+}
+
+if (!window._spotifyIFrameAPI) {
+  const existingCallback = window.onSpotifyIframeApiReady;
+  window.onSpotifyIframeApiReady = (api: SpotifyIFrameAPI) => {
+    window._spotifyIFrameAPI = api;
+    existingCallback?.(api);
+  };
+}
+
+export function useSpotifyEmbed(
+  containerEl: HTMLDivElement | null,
+  onTrackEnd?: () => void
+) {
+  const [isReady, setIsReady] = useState(false);
+  const controllerRef = useRef<SpotifyController | null>(null);
+  const onTrackEndRef = useRef(onTrackEnd);
+  onTrackEndRef.current = onTrackEnd;
+  const endFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (!containerEl) return;
+    if (controllerRef.current) return;
+
+    loadSpotifyScript();
+
+    const init = (api: SpotifyIFrameAPI) => {
+      api.createController(
+        containerEl,
+        { width: '100%', height: 152 },
+        (controller) => {
+          controllerRef.current = controller;
+          setIsReady(true);
+
+          controller.addListener('playback_update', (e: PlaybackUpdate) => {
+            const { isPaused, position, duration } = e.data;
+            if (!isPaused && duration > 0 && position >= duration - 1000) {
+              if (!endFiredRef.current) {
+                endFiredRef.current = true;
+                onTrackEndRef.current?.();
+              }
+            } else {
+              endFiredRef.current = false;
+            }
+          });
+        }
+      );
+    };
+
+    if (window._spotifyIFrameAPI) {
+      init(window._spotifyIFrameAPI);
+    } else {
+      const prev = window.onSpotifyIframeApiReady;
+      window.onSpotifyIframeApiReady = (api) => {
+        window._spotifyIFrameAPI = api;
+        prev?.(api);
+        init(api);
+      };
+    }
+
+    return () => {
+      if (controllerRef.current) {
+        controllerRef.current.destroy();
+        controllerRef.current = null;
+      }
+      setIsReady(false);
+    };
+  }, [containerEl]);
+
+  const loadUri = useCallback((uri: string) => {
+    controllerRef.current?.loadUri(uri);
+    setTimeout(() => controllerRef.current?.play(), 300);
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    controllerRef.current?.togglePlay();
+  }, []);
+
+  return { isReady, loadUri, togglePlay };
+}

--- a/src/hooks/useSpotifyMood.ts
+++ b/src/hooks/useSpotifyMood.ts
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react';
+import { READING_MOODS, getRandomQuery, type ReadingMood } from '@/lib/spotify/moods';
+import { searchTracks, isSpotifyAuthenticated, startSpotifyAuth, type SpotifyTrack } from '@/lib/spotify/api';
+import type { BookSettings } from '@/types/book';
+
+interface UseSpotifyMoodReturn {
+  selectedMood: ReadingMood | null;
+  setMood: (mood: ReadingMood | null) => void;
+  tracks: SpotifyTrack[];
+  loading: boolean;
+  error: string | null;
+  isAuthenticated: boolean;
+  connectSpotify: () => void;
+}
+
+export function useSpotifyMood(
+  settings: BookSettings | null,
+  saveSettings: (partial: Partial<BookSettings>) => Promise<void>
+): UseSpotifyMoodReturn {
+  const [selectedMood, setSelectedMood] = useState<ReadingMood | null>(null);
+  const [tracks, setTracks] = useState<SpotifyTrack[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(isSpotifyAuthenticated);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  useEffect(() => {
+    setIsAuthenticated(isSpotifyAuthenticated());
+  }, []);
+
+  useEffect(() => {
+    if (settings?.spotifyMood && settings.spotifyMood in READING_MOODS) {
+      setSelectedMood(settings.spotifyMood as ReadingMood);
+    }
+  }, [settings]);
+
+  useEffect(() => {
+    if (!selectedMood) {
+      setTracks([]);
+      return;
+    }
+
+    if (!isAuthenticated) return;
+
+    setLoading(true);
+    setError(null);
+
+    searchTracks(getRandomQuery(selectedMood))
+      .then((fetchedTracks) => {
+        setTracks(fetchedTracks);
+      })
+      .catch((e: Error) => {
+        setError(e.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [selectedMood, isAuthenticated, fetchKey]);
+
+  const setMood = (mood: ReadingMood | null) => {
+    if (mood === selectedMood) {
+      // Re-clicking same mood fetches fresh results
+      setFetchKey((k) => k + 1);
+    } else {
+      setSelectedMood(mood);
+    }
+    saveSettings({ spotifyMood: mood }).catch(() => {});
+  };
+
+  const connectSpotify = () => {
+    startSpotifyAuth();
+  };
+
+  return {
+    selectedMood,
+    setMood,
+    tracks,
+    loading,
+    error,
+    isAuthenticated,
+    connectSpotify,
+  };
+}

--- a/src/lib/spotify/api.ts
+++ b/src/lib/spotify/api.ts
@@ -1,0 +1,187 @@
+export interface SpotifyTrack {
+  uri: string;
+  name: string;
+  artist: string;
+  albumArt: string | null;
+}
+
+const CLIENT_ID = import.meta.env.VITE_SPOTIFY_CLIENT_ID;
+const REDIRECT_URI = import.meta.env.PROD
+  ? `${window.location.origin}/callback/spotify`
+  : 'http://127.0.0.1:5173/callback/spotify';
+const SCOPES = 'user-read-private';
+const TOKEN_KEY = 'spotify_token';
+const EXPIRY_KEY = 'spotify_token_expiry';
+const REFRESH_KEY = 'spotify_refresh_token';
+const VERIFIER_KEY = 'spotify_pkce_verifier';
+const STATE_KEY = 'spotify_oauth_state';
+const RETURN_URL_KEY = 'spotify_return_url';
+
+function getStoredToken(): string | null {
+  const token = localStorage.getItem(TOKEN_KEY);
+  const expiry = localStorage.getItem(EXPIRY_KEY);
+  if (token && expiry && Date.now() < Number(expiry)) return token;
+  return null;
+}
+
+function storeToken(token: string, expiresIn: number, refreshToken?: string) {
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(EXPIRY_KEY, String(Date.now() + expiresIn * 1000));
+  if (refreshToken) localStorage.setItem(REFRESH_KEY, refreshToken);
+}
+
+export function clearSpotifyAuth() {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(EXPIRY_KEY);
+  localStorage.removeItem(REFRESH_KEY);
+}
+
+async function refreshAccessToken(): Promise<string | null> {
+  const refreshToken = localStorage.getItem(REFRESH_KEY);
+  if (!refreshToken) return null;
+
+  const response = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!response.ok) {
+    clearSpotifyAuth();
+    return null;
+  }
+
+  const data = await response.json();
+  if (!data.access_token) return null;
+
+  storeToken(data.access_token, data.expires_in, data.refresh_token);
+  return data.access_token;
+}
+
+async function getToken(): Promise<string | null> {
+  return getStoredToken() ?? refreshAccessToken();
+}
+
+export function isSpotifyAuthenticated(): boolean {
+  return getStoredToken() !== null || localStorage.getItem(REFRESH_KEY) !== null;
+}
+
+async function generateCodeVerifier(): Promise<string> {
+  const array = new Uint8Array(64);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('').slice(0, 128);
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function generateState(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function startSpotifyAuth() {
+  const verifier = await generateCodeVerifier();
+  const challenge = await generateCodeChallenge(verifier);
+  const state = generateState();
+  localStorage.setItem(VERIFIER_KEY, verifier);
+  localStorage.setItem(STATE_KEY, state);
+  localStorage.setItem(RETURN_URL_KEY, window.location.pathname);
+
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    scope: SCOPES,
+    code_challenge_method: 'S256',
+    code_challenge: challenge,
+    state,
+  });
+
+  window.location.href = `https://accounts.spotify.com/authorize?${params}`;
+}
+
+export async function handleSpotifyCallback(code: string, state: string): Promise<boolean> {
+  const storedState = localStorage.getItem(STATE_KEY);
+  if (!storedState || storedState !== state) {
+    console.error('Spotify OAuth state mismatch — possible CSRF');
+    return false;
+  }
+  localStorage.removeItem(STATE_KEY);
+
+  const verifier = localStorage.getItem(VERIFIER_KEY);
+  if (!verifier) {
+    console.error('Spotify PKCE verifier not found in localStorage');
+    return false;
+  }
+
+  const response = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: verifier,
+    }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    console.error('Spotify token exchange failed:', response.status, err);
+    return false;
+  }
+
+  const data = await response.json();
+
+  if (!data.access_token || typeof data.expires_in !== 'number') {
+    console.error('Spotify token response missing required fields:', data);
+    return false;
+  }
+
+  storeToken(data.access_token, data.expires_in, data.refresh_token);
+  localStorage.removeItem(VERIFIER_KEY);
+  return true;
+}
+
+export function getAndClearReturnUrl(): string {
+  const url = localStorage.getItem(RETURN_URL_KEY) || '/library';
+  localStorage.removeItem(RETURN_URL_KEY);
+  return url;
+}
+
+export async function searchTracks(query: string, limit = 10): Promise<SpotifyTrack[]> {
+  const token = await getToken();
+  if (!token) throw new Error('Not authenticated with Spotify');
+
+  const response = await fetch(
+    `https://api.spotify.com/v1/search?type=track&q=${encodeURIComponent(query)}&limit=${limit}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!response.ok) {
+    if (response.status === 401) clearSpotifyAuth();
+    const err = await response.text();
+    throw new Error(`Search failed (${response.status}): ${err}`);
+  }
+
+  const data = await response.json();
+  return data.tracks.items.map((track: any) => ({
+    uri: track.uri,
+    name: track.name,
+    artist: track.artists[0]?.name || '',
+    albumArt: track.album.images[0]?.url || null,
+  }));
+}

--- a/src/lib/spotify/moods.ts
+++ b/src/lib/spotify/moods.ts
@@ -1,0 +1,89 @@
+export const READING_MOODS = {
+  peaceful: {
+    label: "Peaceful",
+    emoji: "🌿",
+    queries: [
+      "calm ambient instrumental reading",
+      "peaceful nature sounds instrumental",
+      "gentle piano relaxing background",
+      "serene acoustic meditation music",
+    ],
+  },
+  dark: {
+    label: "Dark",
+    emoji: "🌑",
+    queries: [
+      "dark ambient atmospheric instrumental",
+      "dark cinematic drone soundscape",
+      "gothic ambient dark orchestral",
+      "eerie ambient horror instrumental",
+    ],
+  },
+  epic: {
+    label: "Epic",
+    emoji: "⚔️",
+    queries: [
+      "epic orchestral cinematic instrumental",
+      "heroic battle soundtrack orchestral",
+      "epic trailer music instrumental",
+      "grand symphonic adventure score",
+    ],
+  },
+  romantic: {
+    label: "Romantic",
+    emoji: "💕",
+    queries: [
+      "soft acoustic love instrumental",
+      "romantic piano ballad instrumental",
+      "gentle love songs acoustic guitar",
+      "tender romantic strings instrumental",
+    ],
+  },
+  tense: {
+    label: "Tense",
+    emoji: "😰",
+    queries: [
+      "suspense thriller dark instrumental",
+      "tense dramatic orchestral score",
+      "psychological thriller ambient music",
+      "intense suspenseful cinematic soundtrack",
+    ],
+  },
+  melancholy: {
+    label: "Melancholy",
+    emoji: "🌧️",
+    queries: [
+      "sad piano melancholy instrumental",
+      "melancholic cello emotional music",
+      "bittersweet ambient piano solo",
+      "sorrowful strings emotional soundtrack",
+    ],
+  },
+  whimsical: {
+    label: "Whimsical",
+    emoji: "✨",
+    queries: [
+      "whimsical fantasy playful instrumental",
+      "magical fairy tale music orchestral",
+      "enchanted forest fantasy soundtrack",
+      "lighthearted quirky adventure music",
+    ],
+  },
+  focus: {
+    label: "Focus",
+    emoji: "🎯",
+    queries: [
+      "lo-fi study beats instrumental",
+      "deep focus ambient electronic",
+      "concentration music minimal beats",
+      "study chill hip hop instrumental",
+    ],
+  },
+} as const;
+
+export type ReadingMood = keyof typeof READING_MOODS;
+
+export function getRandomQuery(mood: ReadingMood): string {
+  const queries = READING_MOODS[mood].queries;
+  return queries[Math.floor(Math.random() * queries.length)];
+}

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -14,6 +14,7 @@ import { ReaderChapterSheet } from "@/components/reader/ReaderChapterSheet";
 import { ReaderNavigation } from "@/components/reader/ReaderNavigation";
 import { ReaderProgress } from "@/components/reader/ReaderProgress";
 import { ReaderScrubSheet } from "@/components/reader/ReaderScrubSheet";
+import { SpotifyMoodPlayer } from "@/components/reader/SpotifyMoodPlayer";
 import { IndexedDBService } from "@/lib/db/indexedDB";
 import {
   type ReadingTheme,
@@ -237,6 +238,11 @@ export default function Reader() {
           />
         </footer>
       )}
+
+      <SpotifyMoodPlayer
+        settings={settings}
+        saveSettings={saveSettings}
+      />
     </div>
   );
 }

--- a/src/pages/SpotifyCallback.tsx
+++ b/src/pages/SpotifyCallback.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { handleSpotifyCallback, getAndClearReturnUrl } from '@/lib/spotify/api';
+
+export default function SpotifyCallback() {
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const state = params.get('state');
+    const err = params.get('error');
+
+    if (err) {
+      setError(`Spotify auth failed: ${err}`);
+      return;
+    }
+
+    if (code && state) {
+      handleSpotifyCallback(code, state).then((success) => {
+        if (success) {
+          navigate(getAndClearReturnUrl(), { replace: true });
+        } else {
+          setError('Failed to exchange token with Spotify');
+        }
+      });
+    } else {
+      navigate('/library', { replace: true });
+    }
+  }, [navigate]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-2">
+        <p className="text-sm text-red-500">{error}</p>
+        <button className="text-sm underline" onClick={() => navigate('/library')}>
+          Back to Library
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p className="text-sm text-muted-foreground">Connecting to Spotify...</p>
+    </div>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate } from "react-router-dom";
 import Library from "@/pages/Library";
 import Reader from "@/pages/Reader";
 import Feed from "@/pages/Feed";
+import SpotifyCallback from "@/pages/SpotifyCallback";
 
 export const router = createBrowserRouter([
   {
@@ -15,6 +16,10 @@ export const router = createBrowserRouter([
   {
     path: "/read/:bookId",
     element: <Reader />,
+  },
+  {
+    path: "/callback/spotify",
+    element: <SpotifyCallback />,
   },
   {
     path: "/feed",

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -25,6 +25,7 @@ export interface BookLocations {
 export interface BookSettings {
   bookHash: string;
   disableBottomScrubber: boolean;
+  spotifyMood: string | null;
   updatedAt: number;
 }
 
@@ -42,3 +43,5 @@ export interface StoredBook {
   fileHash: string;
   data: ArrayBuffer;
 }
+
+export type { ReadingMood } from "@/lib/spotify/moods";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  server: {
+    host: '127.0.0.1',
+  },
 })


### PR DESCRIPTION
- Spotify embed player in the reader with mood selection (8 moods)
- PKCE auth flow for Spotify Web API search (no client secret needed)
- Mood persists per book via IndexedDB settings
- Auto-advance to next track when current track ends
- Prev/next track controls
- Player stays alive when collapsed
- Spotify callback route for OAuth redirect
- .env.example with VITE_SPOTIFY_CLIENT_ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Spotify mood-based music player for reading sessions with eight mood options (peaceful, dark, epic, romantic, tense, melancholy, whimsical, focus).
  * Integrated Spotify authentication for music playback during reading.
  * Added track navigation and playback controls within the reader interface.

* **Chores**
  * Updated environment and project configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->