### PR TITLE
fix(tests): repair broken test imports and Convex mock (51/51 green)

### DIFF
--- a/tests/useMobileBottomChromeMotion.test.ts
+++ b/tests/useMobileBottomChromeMotion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { clamp } from "@/lib/utils/math";
 import {
   clampToEndpoint,
-  clamp,
   computeAdaptiveLerpFactor,
   computeTrackedOffset,
   computeViewportBottomAnchor,

--- a/tests/useReadingProgress.test.tsx
+++ b/tests/useReadingProgress.test.tsx
@@ -4,6 +4,12 @@ import { useReadingProgress } from "../src/hooks/useReadingProgress";
 import { IndexedDBService } from "../src/lib/db/indexedDB";
 import { FakeRendition } from "./tooling/fakeRendition";
 
+vi.mock("convex/react", () => {
+  // Real useMutation returns a referentially stable function across renders.
+  const stableMutation = vi.fn(() => Promise.resolve());
+  return { useMutation: vi.fn(() => stableMutation) };
+});
+
 vi.mock("@/lib/db/indexedDB", () => ({
   IndexedDBService: {
     getProgress: vi.fn(),


### PR DESCRIPTION
Fixes the 4 pre-existing test failures on main:

- `tests/useMobileBottomChromeMotion.test.ts` imported `clamp` from the hook, but it moved to `src/lib/utils/math.ts` — import updated.
- `tests/useReadingProgress.test.tsx` (3 failures) — `useReadingProgress` now calls `useMutation(api.readingProgress.updateProgress)`, which crashed without a ConvexProvider. Added a `convex/react` mock that returns a referentially stable mutation function (matching real `useMutation` semantics; an unstable one re-triggers the relocation effect and clears pending debounce timers).

Result: 13/13 files, 51/51 tests passing. No production code changes.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved import organization and mocking configuration to ensure consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->