### PR TITLE
feat(library): right-click to delete books (closes #14)

### DIFF
--- a/src/components/library/BookCard.tsx
+++ b/src/components/library/BookCard.tsx
@@ -53,6 +53,15 @@ export function BookCard({ book, index, onDelete }: BookCardProps) {
     clearLongPressTimer();
   };
 
+  const handleContextMenu = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    clearLongPressTimer();
+    // Touch long-press also fires contextmenu; suppress the trailing click
+    // so it can't navigate while the dialog is open.
+    longPressTriggeredRef.current = true;
+    setDeleteOpen(true);
+  };
+
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (longPressTriggeredRef.current) {
       event.preventDefault();
@@ -71,6 +80,7 @@ export function BookCard({ book, index, onDelete }: BookCardProps) {
         onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerLeave}
         onPointerCancel={handlePointerCancel}
+        onContextMenu={handleContextMenu}
         className="group text-left w-full"
         style={{ animationDelay: `${index * 60}ms` }}
       >


### PR DESCRIPTION
Adds an `onContextMenu` handler to `BookCard` that opens the existing delete-confirmation dialog, so desktop users can right-click a book instead of long-pressing.

Details:
- Right-click prevents the native browser menu and opens the same `Dialog` the 500ms long-press uses — no new UI.
- On Android, a touch long-press also fires `contextmenu`; the handler clears the long-press timer and sets the suppression flag so the trailing click cannot navigate into the reader while the dialog is open.

Verified: eslint clean, `tsc -b` clean, 51/51 tests pass.

Closes #14

Generated with [Claude Code](https://claude.com/claude-code)