### PR TITLE
fix(library): compact mobile header (closes #25)

### DIFF
--- a/src/components/library/BookUpload.tsx
+++ b/src/components/library/BookUpload.tsx
@@ -74,12 +74,14 @@ export function BookUpload({ onUploadComplete }: BookUploadProps) {
         {uploading ? (
           <>
             <Upload className="h-4 w-4 animate-pulse" />
-            Importing...
+            <span className="sm:hidden">Importing</span>
+            <span className="hidden sm:inline">Importing...</span>
           </>
         ) : (
           <>
             <Plus className="h-4 w-4" />
-            Add Book
+            <span className="sm:hidden">Add</span>
+            <span className="hidden sm:inline">Add Book</span>
           </>
         )}
       </Button>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -15,14 +15,14 @@ export default function Library() {
     <PageTransition className="min-h-screen bg-background">
       {/* Header */}
       <header className="sticky top-0 z-20 bg-background/80 backdrop-blur-md border-b border-border/50">
-        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
-          <h1 className="font-display text-2xl font-semibold tracking-tight">
+        <div className="max-w-5xl mx-auto px-3 sm:px-4 py-3 sm:py-4 flex items-center justify-between gap-2">
+          <h1 className="font-display text-xl sm:text-2xl font-semibold tracking-tight shrink-0">
             Shelves
           </h1>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2">
             <SignedOut>
               <SignInButton mode="modal">
-                <Button variant="secondary" size="default">
+                <Button variant="secondary" size="default" className="px-3 sm:px-4">
                   Log-In
                 </Button>
               </SignInButton>
@@ -31,9 +31,9 @@ export default function Library() {
               <UserButton />
             </SignedIn>
             <Button asChild variant="secondary" size="default">
-              <Link to="/feed">
-                <ScrollText className="mr-2 h-4 w-4" />
-                <span>Chronicles</span>
+              <Link to="/feed" aria-label="Chronicles">
+                <ScrollText className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Chronicles</span>
               </Link>
             </Button>
             <BookUpload onUploadComplete={refresh} />


### PR DESCRIPTION
Fixes the mobile header crowding shown in #25: on narrow viewports the Log-In / Chronicles / Add Book buttons overlapped the "Shelves" wordmark and the Add Book button clipped off the right edge.

Changes (all below the `sm` breakpoint; desktop unchanged):
- Tighter header padding (`px-3 py-3`) and button gaps (`gap-1.5`), plus a guaranteed gap between wordmark and actions.
- Wordmark drops to `text-xl` and is `shrink-0` so it can never be overlapped.
- Chronicles button becomes icon-only with an `aria-label` (label returns at `sm:`).
- Upload CTA reads "Add" on mobile, "Add Book" on `sm:+`.

Verified in a 375x812 preview (signed-out state, the widest case): one line, no overlap, no clipping. eslint, `tsc -b`, and all 51 tests pass.

Closes #25

Generated with [Claude Code](https://claude.com/claude-code)
