### PR TITLE
fix(reader): full-surface text selection + share pill below selection (closes #24, #8)

### DIFF
--- a/src/components/reader/HighlightTooltip.tsx
+++ b/src/components/reader/HighlightTooltip.tsx
@@ -1,4 +1,5 @@
 import type { HighlightColor, ToolbarState, DeleteTarget } from "@/hooks/useHighlights";
+import { computeTooltipPlacement } from "@/lib/reader/tooltipPlacement";
 
 const COLORS: { key: HighlightColor; bg: string; ring: string }[] = [
   { key: "yellow", bg: "bg-yellow-300", ring: "ring-yellow-400" },
@@ -26,10 +27,16 @@ export function HighlightTooltip({
 }: HighlightTooltipProps) {
   const isDeleteMode = deleteTarget !== null;
   const rawX = isDeleteMode ? deleteTarget.x : toolbarState.x;
-  const rawY = isDeleteMode ? deleteTarget.y : toolbarState.y;
+  const anchorTop = isDeleteMode ? deleteTarget.y : toolbarState.y;
+  const anchorBottom = isDeleteMode ? deleteTarget.yBottom : toolbarState.yBottom;
 
-  // Clamp so the pill never goes off-screen
-  const top = Math.max(rawY - 56, 60);
+  // Below the selection (the native selection menu owns the space above it);
+  // clamp so the pill never goes off-screen.
+  const { top, caret } = computeTooltipPlacement(
+    anchorTop,
+    anchorBottom,
+    window.innerHeight
+  );
   const left = Math.min(Math.max(rawX, 80), window.innerWidth - 80);
 
   return (
@@ -135,15 +142,26 @@ export function HighlightTooltip({
         )}
       </div>
 
-      {/* Down-pointing caret */}
-      <div
-        className="absolute left-1/2 -translate-x-1/2 -bottom-2 w-0 h-0"
-        style={{
-          borderLeft: "6px solid transparent",
-          borderRight: "6px solid transparent",
-          borderTop: "8px solid rgba(23,23,23,0.95)",
-        }}
-      />
+      {/* Caret pointing at the anchored text */}
+      {caret === "up" ? (
+        <div
+          className="absolute left-1/2 -translate-x-1/2 -top-2 w-0 h-0"
+          style={{
+            borderLeft: "6px solid transparent",
+            borderRight: "6px solid transparent",
+            borderBottom: "8px solid rgba(23,23,23,0.95)",
+          }}
+        />
+      ) : (
+        <div
+          className="absolute left-1/2 -translate-x-1/2 -bottom-2 w-0 h-0"
+          style={{
+            borderLeft: "6px solid transparent",
+            borderRight: "6px solid transparent",
+            borderTop: "8px solid rgba(23,23,23,0.95)",
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/reader/ReaderNavigation.tsx
+++ b/src/components/reader/ReaderNavigation.tsx
@@ -8,10 +8,12 @@ interface ReaderNavigationProps {
 export function ReaderNavigation({ onPrev, onNext }: ReaderNavigationProps) {
   return (
     <>
-      {/* Left tap zone */}
+      {/* Slim edge strips: desktop hover affordance only. Tap navigation is
+          handled inside the iframe (useReaderTapZones) so the reading surface
+          stays free for text selection. */}
       <button
         onClick={onPrev}
-        className="absolute left-0 top-0 w-[15%] h-full z-10 flex items-center justify-start pl-2 opacity-0 hover:opacity-100 transition-opacity duration-200"
+        className="absolute left-0 top-0 w-12 h-full z-10 flex items-center justify-start pl-2 opacity-0 hover:opacity-100 transition-opacity duration-200"
         aria-label="Previous page"
       >
         <div className="bg-background/60 backdrop-blur-sm rounded-full p-2 shadow-sm">
@@ -19,10 +21,9 @@ export function ReaderNavigation({ onPrev, onNext }: ReaderNavigationProps) {
         </div>
       </button>
 
-      {/* Right tap zone */}
       <button
         onClick={onNext}
-        className="absolute right-0 top-0 w-[15%] h-full z-10 flex items-center justify-end pr-2 opacity-0 hover:opacity-100 transition-opacity duration-200"
+        className="absolute right-0 top-0 w-12 h-full z-10 flex items-center justify-end pr-2 opacity-0 hover:opacity-100 transition-opacity duration-200"
         aria-label="Next page"
       >
         <div className="bg-background/60 backdrop-blur-sm rounded-full p-2 shadow-sm">

--- a/src/components/reader/ShareHighlightSheet.tsx
+++ b/src/components/reader/ShareHighlightSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { NewChronicleDraft } from "@/hooks/useChronicles";
 import {
   Drawer,
@@ -31,13 +31,16 @@ export function ShareHighlightSheet({
   const [comment, setComment] = useState("");
   const [spoilerTag, setSpoilerTag] = useState(false);
 
-  // Reset fields each time the sheet opens
-  useEffect(() => {
+  // Reset fields each time the sheet opens (state adjustment during render,
+  // per React docs, instead of a cascading setState-in-effect)
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
     if (open) {
       setComment("");
       setSpoilerTag(false);
     }
-  }, [open]);
+  }
 
   const charCount = comment.length;
   const overLimit = charCount > MAX_CHARS;

--- a/src/hooks/useHighlights.ts
+++ b/src/hooks/useHighlights.ts
@@ -26,12 +26,14 @@ export interface ToolbarState {
   pendingText: string;
   x: number;
   y: number;
+  yBottom: number;
 }
 
 export interface DeleteTarget {
   cfi: string;
   x: number;
   y: number;
+  yBottom: number;
 }
 
 // epub.js Contents object (partial)
@@ -52,13 +54,16 @@ export function useHighlights(
     pendingText: "",
     x: 0,
     y: 0,
+    yBottom: 0,
   });
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const [hasActiveSelection, setHasActiveSelection] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
   const highlightsRef = useRef<ReaderNote[]>([]);
   const themeRef = useRef(theme);
-  themeRef.current = theme;
+  useEffect(() => {
+    themeRef.current = theme;
+  }, [theme]);
 
   // Load and apply saved highlights whenever the rendition or book changes
   useEffect(() => {
@@ -73,7 +78,11 @@ export function useHighlights(
       // effect re-runs on a theme change (annotations.add is not idempotent
       // at the DOM level even though the internal map entry is overwritten)
       for (const h of highlights) {
-        try { rendition!.annotations.remove(h.cfi, "highlight"); } catch {}
+        try {
+          rendition!.annotations.remove(h.cfi, "highlight");
+        } catch {
+          // Nothing to remove on first render — annotations.add throws if absent
+        }
       }
       for (const h of highlights) {
         const cls = `hl-${h.color}`;
@@ -119,6 +128,7 @@ export function useHighlights(
           pendingText: text,
           x: window.innerWidth / 2,
           y: 120,
+          yBottom: 120,
         });
         return;
       }
@@ -126,12 +136,14 @@ export function useHighlights(
       const iframeRect = iframe.getBoundingClientRect();
       const outerX = iframeRect.left + selRect.left + selRect.width / 2;
       const outerY = iframeRect.top + selRect.top;
+      const outerYBottom = iframeRect.top + selRect.bottom;
 
       setToolbarState({
         pendingCfi: cfiRange,
         pendingText: text,
         x: outerX,
         y: outerY,
+        yBottom: outerYBottom,
       });
     }
 
@@ -142,6 +154,7 @@ export function useHighlights(
     ) {
       let x = window.innerWidth / 2;
       let y = window.innerHeight / 2;
+      let yBottom = window.innerHeight / 2;
 
       try {
         const range = contents.range(cfiRange);
@@ -151,12 +164,13 @@ export function useHighlights(
           const iframeRect = iframe.getBoundingClientRect();
           x = iframeRect.left + rect.left + rect.width / 2;
           y = iframeRect.top + rect.top;
+          yBottom = iframeRect.top + rect.bottom;
         }
       } catch {
         // fallback to center if range lookup fails
       }
 
-      setDeleteTarget({ cfi: cfiRange, x, y });
+      setDeleteTarget({ cfi: cfiRange, x, y, yBottom });
     }
 
     rendition.on("selected", handleSelected);
@@ -169,7 +183,7 @@ export function useHighlights(
   }, [rendition, viewerRef]);
 
   const dismissToolbar = useCallback(() => {
-    setToolbarState({ pendingCfi: null, pendingText: "", x: 0, y: 0 });
+    setToolbarState({ pendingCfi: null, pendingText: "", x: 0, y: 0, yBottom: 0 });
     setDeleteTarget(null);
     setHasActiveSelection(false);
     const iframe = viewerRef.current?.querySelector(

--- a/src/hooks/useReaderTapZones.ts
+++ b/src/hooks/useReaderTapZones.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import type { Rendition } from "epubjs";
+import { iframeClickToViewportX, resolveTapZone } from "@/lib/reader/tapZones";
+
+interface TapZoneHandlers {
+  onPrev: () => void;
+  onNext: () => void;
+  onToggle: () => void;
+  /**
+   * Called instead of the zone action when a tap lands while a text selection
+   * or highlight toolbar is active. Returns true when the tap was consumed.
+   */
+  onInterceptTap?: () => boolean;
+}
+
+/**
+ * Page navigation via taps on the book text itself.
+ *
+ * epub.js relays DOM click events from the section iframe to the rendition.
+ * Handling taps there (instead of overlay buttons stacked above the iframe)
+ * keeps the entire reading surface available for native text selection —
+ * overlay zones swallow the pointer events selection needs.
+ */
+export function useReaderTapZones(
+  rendition: Rendition | null,
+  viewerRef: React.RefObject<HTMLDivElement | null>,
+  handlers: TapZoneHandlers
+) {
+  const handlersRef = useRef(handlers);
+  useEffect(() => {
+    handlersRef.current = handlers;
+  }, [handlers]);
+
+  useEffect(() => {
+    if (!rendition) return;
+
+    const handleClick = (event: MouseEvent) => {
+      const viewer = viewerRef.current;
+      if (!viewer) return;
+
+      const iframe = viewer.querySelector("iframe");
+
+      // A click that ends a drag-selection (or adjusts selection handles)
+      // must never turn the page.
+      const selection = iframe?.contentWindow?.getSelection();
+      if (selection && !selection.isCollapsed && selection.toString().trim()) {
+        return;
+      }
+
+      if (handlersRef.current.onInterceptTap?.()) return;
+
+      const viewerRect = viewer.getBoundingClientRect();
+      const iframeRect = iframe?.getBoundingClientRect();
+      const viewportX = iframeRect
+        ? iframeClickToViewportX(event.clientX, iframeRect.left)
+        : viewerRect.left + event.clientX;
+
+      const zone = resolveTapZone(viewportX - viewerRect.left, viewerRect.width);
+      if (zone === "prev") handlersRef.current.onPrev();
+      else if (zone === "next") handlersRef.current.onNext();
+      else handlersRef.current.onToggle();
+    };
+
+    rendition.on("click", handleClick);
+    return () => {
+      rendition.off("click", handleClick);
+    };
+  }, [rendition, viewerRef]);
+}

--- a/src/lib/reader/tapZones.ts
+++ b/src/lib/reader/tapZones.ts
@@ -1,0 +1,29 @@
+export type TapZone = "prev" | "toggle" | "next";
+
+const EDGE_ZONE_FRACTION = 0.3;
+
+/**
+ * Map a tap's x position (in outer viewport pixels, relative to the viewer's
+ * left edge) to a reader action zone: left 30% = previous page, right 30% =
+ * next page, middle 40% = toggle the reading chrome.
+ */
+export function resolveTapZone(visibleX: number, viewerWidth: number): TapZone {
+  if (viewerWidth <= 0) return "toggle";
+  const fraction = visibleX / viewerWidth;
+  if (fraction < EDGE_ZONE_FRACTION) return "prev";
+  if (fraction > 1 - EDGE_ZONE_FRACTION) return "next";
+  return "toggle";
+}
+
+/**
+ * Convert a click's clientX inside an epub.js section iframe to the outer
+ * viewport x position. Paginated sections render as a wide multi-column strip,
+ * so the iframe's bounding rect left edge is negative once the reader has
+ * scrolled — adding clientX yields the on-screen position.
+ */
+export function iframeClickToViewportX(
+  clientX: number,
+  iframeRectLeft: number
+): number {
+  return iframeRectLeft + clientX;
+}

--- a/src/lib/reader/tooltipPlacement.ts
+++ b/src/lib/reader/tooltipPlacement.ts
@@ -1,0 +1,30 @@
+export interface TooltipPlacement {
+  top: number;
+  caret: "up" | "down";
+}
+
+const PILL_HEIGHT = 48;
+const ANCHOR_GAP = 14;
+const VIEWPORT_MARGIN = 16;
+const TOP_SAFE_AREA = 60;
+
+/**
+ * Place the highlight pill below the selected text so it never fights the
+ * native selection menu, which mobile browsers draw above the selection and
+ * which cannot be suppressed. Flips above only when the selection sits too
+ * close to the bottom of the viewport.
+ */
+export function computeTooltipPlacement(
+  anchorTop: number,
+  anchorBottom: number,
+  viewportHeight: number
+): TooltipPlacement {
+  const below = anchorBottom + ANCHOR_GAP;
+  if (below + PILL_HEIGHT <= viewportHeight - VIEWPORT_MARGIN) {
+    return { top: below, caret: "up" };
+  }
+  return {
+    top: Math.max(anchorTop - PILL_HEIGHT - ANCHOR_GAP + 6, TOP_SAFE_AREA),
+    caret: "down",
+  };
+}

--- a/src/pages/Reader.tsx
+++ b/src/pages/Reader.tsx
@@ -26,6 +26,7 @@ import {
   FONT_FAMILIES,
 } from "@/lib/theme/readingThemes";
 import { useHighlights } from "@/hooks/useHighlights";
+import { useReaderTapZones } from "@/hooks/useReaderTapZones";
 
 export default function Reader() {
   const { bookId } = useParams<{ bookId: string }>();
@@ -103,11 +104,27 @@ export default function Reader() {
   }, [bookId]);
 
 
-  // Toggle controls on center tap — dismiss highlight toolbar first if active
-  const handleCenterTap = useCallback(() => {
-    if (hasActiveSelection) { dismissToolbar(); return; }
+  // Taps on the book text itself: left/right zones turn pages, the middle
+  // toggles the chrome. Handled inside the iframe (via epub.js relayed
+  // clicks) so the full surface stays free for native text selection.
+  const handleToggleControls = useCallback(() => {
     setShowControls((prev) => !prev);
-  }, [hasActiveSelection, dismissToolbar]);
+  }, []);
+
+  const handleInterceptTap = useCallback(() => {
+    if (hasActiveSelection || deleteTarget !== null) {
+      dismissToolbar();
+      return true;
+    }
+    return false;
+  }, [hasActiveSelection, deleteTarget, dismissToolbar]);
+
+  useReaderTapZones(rendition, viewerRef, {
+    onPrev: goPrev,
+    onNext: goNext,
+    onToggle: handleToggleControls,
+    onInterceptTap: handleInterceptTap,
+  });
 
   const handleAddCurrentBookmark = useCallback(() => {
     if (!currentBookmarkCfi) return;
@@ -129,12 +146,16 @@ export default function Reader() {
   // the tooltip's onTouchStart stopPropagation, so we check the target here).
   useEffect(() => {
     if (shareOpen) return;
-    const handler = (e: TouchEvent) => {
+    const handler = (e: TouchEvent | MouseEvent) => {
       if ((e.target as Element | null)?.closest("[data-highlight-tooltip]")) return;
       dismissToolbar();
     };
     document.addEventListener("touchstart", handler, { capture: true, passive: true });
-    return () => document.removeEventListener("touchstart", handler, { capture: true });
+    document.addEventListener("mousedown", handler, { capture: true });
+    return () => {
+      document.removeEventListener("touchstart", handler, { capture: true });
+      document.removeEventListener("mousedown", handler, { capture: true });
+    };
   }, [dismissToolbar, shareOpen]);
 
   // Keyboard navigation
@@ -281,13 +302,6 @@ export default function Reader() {
         />
 
         <ReaderNavigation onPrev={goPrev} onNext={goNext} />
-
-        {/* Center tap zone to toggle controls */}
-        <button
-          onClick={handleCenterTap}
-          className="absolute top-0 left-[40%] w-[20%] h-full z-10"
-          aria-label="Toggle controls"
-        />
 
       </div>
 

--- a/tests/readerTapZones.test.ts
+++ b/tests/readerTapZones.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { iframeClickToViewportX, resolveTapZone } from "@/lib/reader/tapZones";
+import { computeTooltipPlacement } from "@/lib/reader/tooltipPlacement";
+
+describe("resolveTapZone", () => {
+  it("maps the left 30% to previous page", () => {
+    expect(resolveTapZone(0, 1000)).toBe("prev");
+    expect(resolveTapZone(299, 1000)).toBe("prev");
+  });
+
+  it("maps the middle 40% to chrome toggle", () => {
+    expect(resolveTapZone(300, 1000)).toBe("toggle");
+    expect(resolveTapZone(500, 1000)).toBe("toggle");
+    expect(resolveTapZone(700, 1000)).toBe("toggle");
+  });
+
+  it("maps the right 30% to next page", () => {
+    expect(resolveTapZone(701, 1000)).toBe("next");
+    expect(resolveTapZone(999, 1000)).toBe("next");
+  });
+
+  it("falls back to toggle for a degenerate viewer width", () => {
+    expect(resolveTapZone(100, 0)).toBe("toggle");
+  });
+});
+
+describe("iframeClickToViewportX", () => {
+  it("offsets click x by the iframe strip position", () => {
+    // Page 3 of a paginated strip: iframe rect.left is -2 page widths.
+    expect(iframeClickToViewportX(850, -800)).toBe(50);
+    expect(iframeClickToViewportX(120, 0)).toBe(120);
+  });
+});
+
+describe("computeTooltipPlacement", () => {
+  it("places the pill below the selection when there is room", () => {
+    const placement = computeTooltipPlacement(200, 220, 800);
+    expect(placement.caret).toBe("up");
+    expect(placement.top).toBeGreaterThan(220);
+  });
+
+  it("flips above the selection near the viewport bottom", () => {
+    const placement = computeTooltipPlacement(740, 760, 800);
+    expect(placement.caret).toBe("down");
+    expect(placement.top).toBeLessThan(740);
+  });
+
+  it("never crosses the top safe area when flipped", () => {
+    const placement = computeTooltipPlacement(10, 790, 800);
+    expect(placement.top).toBeGreaterThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
## Root cause of #24 / #8

The page-turn overlays covered **50% of the reading surface** (left 15% + right 15% + center 20%, all full-height, stacked above the epub iframe at z-10). Pointer events in those bands never reached the book text, so drag-selecting was only possible in two narrow strips — and when a selection did succeed, the share pill rendered *above* the selection, exactly where iOS/Android draw their (unsuppressible) native selection menu.

## Changes

- **Tap navigation moved inside the iframe** via the epub.js relayed `click` event (`useReaderTapZones` + pure `resolveTapZone`): left 30% = previous, right 30% = next, middle 40% = toggle chrome. The entire surface is now free for native text selection.
- **Selection guards**: a click that ends a drag-selection never turns the page; a tap while the pill is open dismisses it instead of navigating.
- **Pill placement flipped below the selection** (`computeTooltipPlacement`), flipping above only near the viewport bottom — so it coexists with the native selection menu instead of fighting it. Caret flips to match.
- Edge arrows shrunk to slim 48px hover strips (desktop affordance; keyboard nav unchanged).
- Outside-dismiss now handles `mousedown` too (was touch-only, so desktop couldn't dismiss by clicking away).
- Lint fixes in touched files: render-time ref writes (`useHighlights`, new hook) and a setState-in-effect reset in `ShareHighlightSheet` (now the render-time adjustment pattern from the React docs).

## Verification (real browser, real ePub)

Loaded Frankenstein (Gutenberg) through the actual Library upload flow in a dev preview and drove the reader:

- Selecting prose shows the pill **below** the selection (measured: selection bottom 308.7px → pill top 322.7px) ✓
- Share button opens the Chronicle sheet with the quoted text + book title ✓
- Right-zone tap advances the page, left-zone goes back (verified by visible-text change, including across chapter boundaries) ✓
- Center tap toggles the reading chrome on and off ✓
- Tap with the pill open dismisses without turning the page ✓
- A click while a selection still exists does nothing (no accidental page flips) ✓

`eslint` 0 errors, `tsc -b` clean, 59/59 tests (8 new unit tests for zone mapping and pill placement).

Closes #24
Closes #8

Generated with [Claude Code](https://claude.com/claude-code)
