### PR TITLE
feat(feed): cursor pagination + server hydration + lazy replies (closes #27)

### DIFF
--- a/convex/chronicles.ts
+++ b/convex/chronicles.ts
@@ -1,9 +1,23 @@
 import { v } from "convex/values";
-import { internalMutation, mutation, query, type MutationCtx } from "./_generated/server";
-import type { Id } from "./_generated/dataModel";
+import { paginationOptsValidator } from "convex/server";
+import {
+  internalMutation,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "./_generated/server";
+import type { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import { requireAuthenticatedUserId } from "./lib/auth";
 import { clampFeedLimit, rankForYouChronicles, sanitizeNowBucketMs } from "./lib/feedRanking";
+import {
+  decodeFeedCursor,
+  isAfterCursor,
+  selectFeedPage,
+  SAME_TS_BUFFER,
+  type FeedCursor,
+} from "./lib/feedPagination";
 
 const LIST_DEFAULT_LIMIT = 20;
 const FEED_DEFAULT_LIMIT = 40;
@@ -23,6 +37,11 @@ const BATCH_MAX_IDS = 100;
 const CASCADE_NODE_BATCH_SIZE = 20;
 const CASCADE_CHILD_PAGE_SIZE = 20;
 const CASCADE_REACTION_PAGE_SIZE = 50;
+
+// feedPage scan windows: the hard upper bound of index rows read per page.
+const FOLLOWING_PAGE_MAX_SCAN = 400;
+const AUTHOR_PAGE_MAX_SCAN = 300;
+const REACTION_PAGE_SCAN_PAD = 20;
 
 function pushUniqueChronicleId(
   target: Id<"chronicles">[],
@@ -397,6 +416,287 @@ export const userReactionStates = query({
     );
 
     return Object.fromEntries(states);
+  },
+});
+
+interface ViewerReactionState {
+  isLiked: boolean;
+  isReposted: boolean;
+  isBookmarked: boolean;
+}
+
+interface FeedPageItem extends Doc<"chronicles"> {
+  author: {
+    clerkId: string;
+    name?: string;
+    handle?: string;
+    avatarUrl?: string;
+  } | null;
+  viewer: ViewerReactionState | null;
+}
+
+/**
+ * Hydrate a page of chronicles with author records and the viewer's reaction
+ * states in bounded batches — at most one user lookup per distinct author and
+ * three point lookups per chronicle, all capped by the page size.
+ */
+async function hydrateFeedPage(
+  ctx: QueryCtx,
+  chronicles: Doc<"chronicles">[]
+): Promise<FeedPageItem[]> {
+  const authorIds = [...new Set(chronicles.map((chronicle) => chronicle.authorId))];
+  const authorDocs = await Promise.all(
+    authorIds.map((clerkId) =>
+      ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", clerkId))
+        .unique()
+    )
+  );
+  const authorByClerkId = new Map(
+    authorDocs
+      .filter((author): author is NonNullable<typeof author> => author !== null)
+      .map((author) => [author.clerkId, author])
+  );
+
+  const identity = await ctx.auth.getUserIdentity();
+  const viewerId = identity?.subject ?? null;
+
+  const viewerStates = viewerId
+    ? await Promise.all(
+        chronicles.map(async (chronicle) => {
+          const [like, repost, bookmark] = await Promise.all([
+            ctx.db
+              .query("likes")
+              .withIndex("by_user_and_chronicle", (q) =>
+                q.eq("userId", viewerId).eq("chronicleId", chronicle._id)
+              )
+              .unique(),
+            ctx.db
+              .query("reposts")
+              .withIndex("by_user_and_chronicle", (q) =>
+                q.eq("userId", viewerId).eq("chronicleId", chronicle._id)
+              )
+              .unique(),
+            ctx.db
+              .query("bookmarks")
+              .withIndex("by_user_and_chronicle", (q) =>
+                q.eq("userId", viewerId).eq("chronicleId", chronicle._id)
+              )
+              .unique(),
+          ]);
+          return {
+            isLiked: like !== null,
+            isReposted: repost !== null,
+            isBookmarked: bookmark !== null,
+          };
+        })
+      )
+    : null;
+
+  return chronicles.map((chronicle, index) => {
+    const author = authorByClerkId.get(chronicle.authorId);
+    return {
+      ...chronicle,
+      author: author
+        ? {
+            clerkId: author.clerkId,
+            name: author.name,
+            handle: author.handle,
+            avatarUrl: author.avatarUrl,
+          }
+        : null,
+      viewer: viewerStates ? viewerStates[index] : null,
+    };
+  });
+}
+
+function topLevelByCreatedDesc(ctx: QueryCtx, cursor: FeedCursor | null, scanSize: number) {
+  return ctx.db
+    .query("chronicles")
+    .withIndex("by_parent_and_created", (q) => {
+      const base = q.eq("parentChronicleId", undefined);
+      return cursor ? base.lte("createdAt", cursor.t) : base;
+    })
+    .order("desc")
+    .take(scanSize);
+}
+
+async function reactionFeedPage(
+  ctx: QueryCtx,
+  table: "bookmarks" | "likes" | "reposts",
+  userId: string,
+  cursor: FeedCursor | null,
+  pageSize: number
+) {
+  const scanSize = pageSize + REACTION_PAGE_SCAN_PAD;
+  const rows = await ctx.db
+    .query(table)
+    .withIndex("by_user", (q) => {
+      const base = q.eq("userId", userId);
+      return cursor ? base.lt("_creationTime", cursor.ct) : base;
+    })
+    .order("desc")
+    .take(scanSize);
+  const scanExhausted = rows.length < scanSize;
+
+  const chronicleById = new Map<string, Doc<"chronicles">>();
+  await Promise.all(
+    rows.map(async (row) => {
+      if (chronicleById.has(row.chronicleId)) return;
+      const chronicle = await ctx.db.get(row.chronicleId);
+      if (chronicle) chronicleById.set(row.chronicleId, chronicle);
+    })
+  );
+
+  const seen = new Set<string>();
+  const selection = selectFeedPage(
+    rows,
+    (row) => {
+      // Reaction rows are scanned in _creationTime index order, so the
+      // cursor compares _creationTime alone (createdAt may not agree).
+      if (cursor && row._creationTime >= cursor.ct) return false;
+      if (seen.has(row.chronicleId)) return false;
+      const chronicle = chronicleById.get(row.chronicleId);
+      if (!chronicle || chronicle.parentChronicleId !== undefined) return false;
+      seen.add(row.chronicleId);
+      return true;
+    },
+    pageSize,
+    scanExhausted
+  );
+
+  return {
+    chronicles: selection.items.map((row) => chronicleById.get(row.chronicleId)!),
+    continueCursor: selection.continueCursor,
+    isDone: selection.isDone,
+  };
+}
+
+/**
+ * Cursor-paginated, server-hydrated feed (issue #27).
+ *
+ * One round trip returns a page of chronicles with author records and the
+ * viewer's reaction states attached. Every variant reads a bounded number of
+ * index rows per page, so feed cost no longer grows with table size.
+ *
+ * "For You" is a ranked discovery window: the first page ranks the newest
+ * candidate pool (exactly the legacy listForYou behavior); older pages
+ * continue in reverse-chronological order below that pool.
+ */
+export const feedPage = query({
+  args: {
+    feed: v.union(
+      v.literal("forYou"),
+      v.literal("following"),
+      v.literal("author"),
+      v.literal("bookmarks"),
+      v.literal("likes"),
+      v.literal("reposts")
+    ),
+    authorId: v.optional(v.string()),
+    nowBucketMs: v.optional(v.number()),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, { feed, authorId, nowBucketMs, paginationOpts }) => {
+    const pageSize = clampFeedLimit(paginationOpts.numItems, FEED_DEFAULT_LIMIT, FEED_MAX_LIMIT);
+    const cursor = decodeFeedCursor(paginationOpts.cursor);
+
+    let chronicles: Doc<"chronicles">[];
+    let continueCursor: string | null;
+    let isDone: boolean;
+
+    if (feed === "forYou") {
+      // Ranked chronological windows: each page is the next chronological
+      // slice (cursor-stable — pages partition the index, so no duplicates
+      // or gaps), reordered by engagement ranking within the window for
+      // display. The continue cursor follows the chronological spine, never
+      // the display order.
+      const scanSize = pageSize + SAME_TS_BUFFER;
+      const docs = await topLevelByCreatedDesc(ctx, cursor, scanSize);
+      const selection = selectFeedPage(
+        docs,
+        (doc) => cursor === null || isAfterCursor(doc, cursor),
+        pageSize,
+        docs.length < scanSize
+      );
+      chronicles = rankForYouChronicles(
+        selection.items,
+        selection.items.length,
+        sanitizeNowBucketMs(nowBucketMs ?? Date.now())
+      );
+      continueCursor = selection.continueCursor;
+      isDone = selection.isDone;
+    } else if (feed === "following") {
+      const followerId = await requireAuthenticatedUserId(ctx);
+      const follows = await ctx.db
+        .query("follows")
+        .withIndex("by_follower", (q) => q.eq("followerId", followerId))
+        .order("desc")
+        .take(FOLLOWING_MAX_FOLLOWEES);
+      const allowedAuthors = new Set([
+        followerId,
+        ...follows.map((follow) => follow.followeeId),
+      ]);
+
+      const docs = await topLevelByCreatedDesc(ctx, cursor, FOLLOWING_PAGE_MAX_SCAN);
+      const selection = selectFeedPage(
+        docs,
+        (doc) =>
+          (cursor === null || isAfterCursor(doc, cursor)) &&
+          allowedAuthors.has(doc.authorId),
+        pageSize,
+        docs.length < FOLLOWING_PAGE_MAX_SCAN
+      );
+      chronicles = selection.items;
+      continueCursor = selection.continueCursor;
+      isDone = selection.isDone;
+    } else if (feed === "author") {
+      if (!authorId) throw new Error("authorId is required for the author feed");
+      // by_author_and_created matches the cursor's createdAt ordering — the
+      // plain by_author index orders by _creationTime, which is not
+      // guaranteed to agree with createdAt.
+      const docs = await ctx.db
+        .query("chronicles")
+        .withIndex("by_author_and_created", (q) => {
+          const base = q.eq("authorId", authorId);
+          return cursor ? base.lte("createdAt", cursor.t) : base;
+        })
+        .order("desc")
+        .take(AUTHOR_PAGE_MAX_SCAN);
+      const selection = selectFeedPage(
+        docs,
+        (doc) =>
+          doc.parentChronicleId === undefined &&
+          (cursor === null || isAfterCursor(doc, cursor)),
+        pageSize,
+        docs.length < AUTHOR_PAGE_MAX_SCAN
+      );
+      chronicles = selection.items;
+      continueCursor = selection.continueCursor;
+      isDone = selection.isDone;
+    } else {
+      const userId = await requireAuthenticatedUserId(ctx);
+      const table =
+        feed === "bookmarks" ? "bookmarks" : feed === "likes" ? "likes" : "reposts";
+      const result = await reactionFeedPage(ctx, table, userId, cursor, pageSize);
+      chronicles = result.chronicles;
+      continueCursor = result.continueCursor;
+      isDone = result.isDone;
+    }
+
+    const page = await hydrateFeedPage(ctx, chronicles);
+
+    // Telemetry: visible in the Convex dashboard alongside execution time.
+    console.log(
+      `[feedPage] feed=${feed} returned=${page.length} cursor=${cursor !== null} done=${isDone}`
+    );
+
+    return {
+      page,
+      isDone,
+      continueCursor: continueCursor ?? "",
+    };
   },
 });
 

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -1,0 +1,92 @@
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+
+/**
+ * Dev-only seeding helpers for exercising feed pagination locally:
+ *
+ *   npx convex run devSeed:seed '{"count": 45}'
+ *   npx convex run devSeed:cleanup
+ *
+ * Internal mutations — not callable from clients. Seeded rows are marked by
+ * the `seed-user-` author prefix so cleanup can find everything it created.
+ */
+
+const SEED_AUTHOR_PREFIX = "seed-user-";
+const SEED_AUTHOR_COUNT = 3;
+
+export const seed = internalMutation({
+  args: { count: v.optional(v.number()) },
+  handler: async (ctx, { count = 45 }) => {
+    const now = Date.now();
+
+    for (let i = 0; i < SEED_AUTHOR_COUNT; i++) {
+      const clerkId = `${SEED_AUTHOR_PREFIX}${i}`;
+      const existing = await ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", clerkId))
+        .unique();
+      if (!existing) {
+        await ctx.db.insert("users", {
+          clerkId,
+          email: `${clerkId}@example.test`,
+          name: `Seed Reader ${i + 1}`,
+          handle: `seedreader${i + 1}`,
+          searchText: `seed reader ${i + 1} seedreader${i + 1}`,
+        });
+      }
+    }
+
+    const ids = [];
+    for (let i = 0; i < count; i++) {
+      const id = await ctx.db.insert("chronicles", {
+        authorId: `${SEED_AUTHOR_PREFIX}${i % SEED_AUTHOR_COUNT}`,
+        text: `[seed] chronicle #${i + 1} — pagination test post`,
+        likeCount: (i * 7) % 23,
+        replyCount: 0,
+        repostCount: (i * 3) % 11,
+        createdAt: now - i * 60_000,
+      });
+      ids.push(id);
+    }
+
+    // A few replies on the newest chronicle to exercise lazy reply loading.
+    for (let r = 0; r < 3; r++) {
+      await ctx.db.insert("chronicles", {
+        authorId: `${SEED_AUTHOR_PREFIX}${r % SEED_AUTHOR_COUNT}`,
+        text: `[seed] reply #${r + 1}`,
+        parentChronicleId: ids[0],
+        likeCount: 0,
+        replyCount: 0,
+        repostCount: 0,
+        createdAt: now - r * 1000,
+      });
+    }
+    await ctx.db.patch(ids[0], { replyCount: 3 });
+
+    return { inserted: count, replies: 3 };
+  },
+});
+
+export const cleanup = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    let deleted = 0;
+    for (let i = 0; i < SEED_AUTHOR_COUNT; i++) {
+      const authorId = `${SEED_AUTHOR_PREFIX}${i}`;
+      const chronicles = await ctx.db
+        .query("chronicles")
+        .withIndex("by_author", (q) => q.eq("authorId", authorId))
+        .collect();
+      for (const chronicle of chronicles) {
+        await ctx.db.delete(chronicle._id);
+        deleted += 1;
+      }
+      const user = await ctx.db
+        .query("users")
+        .withIndex("by_clerk_id", (q) => q.eq("clerkId", authorId))
+        .unique();
+      if (user) await ctx.db.delete(user._id);
+    }
+    return { deleted };
+  },
+});

--- a/convex/lib/feedPagination.ts
+++ b/convex/lib/feedPagination.ts
@@ -1,0 +1,100 @@
+/**
+ * Cursor contract for feed pagination.
+ *
+ * Cursors encode the index position of the last item the client received:
+ * `createdAt` plus `_creationTime` as a tiebreaker for documents written in
+ * the same millisecond. Pages resume with an inclusive (`lte`) index range and
+ * skip documents at-or-after the cursor position, so concurrent inserts can
+ * never cause duplicates or gaps between pages.
+ */
+
+export interface FeedCursor {
+  /** `createdAt` of the last item on the previous page. */
+  t: number;
+  /** `_creationTime` tiebreaker for same-millisecond documents. */
+  ct: number;
+}
+
+export interface CursorablePosition {
+  createdAt: number;
+  _creationTime: number;
+}
+
+/** Extra rows fetched beyond the page size to absorb same-millisecond ties. */
+export const SAME_TS_BUFFER = 25;
+
+export function encodeFeedCursor(cursor: FeedCursor): string {
+  return JSON.stringify(cursor);
+}
+
+export function decodeFeedCursor(raw: string | null): FeedCursor | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<FeedCursor>;
+    if (typeof parsed.t !== "number" || typeof parsed.ct !== "number") return null;
+    return { t: parsed.t, ct: parsed.ct };
+  } catch {
+    return null;
+  }
+}
+
+/** True when the document sits strictly after (older than) the cursor position. */
+export function isAfterCursor(doc: CursorablePosition, cursor: FeedCursor): boolean {
+  if (doc.createdAt < cursor.t) return true;
+  if (doc.createdAt > cursor.t) return false;
+  return doc._creationTime < cursor.ct;
+}
+
+export interface PageSelection<T> {
+  items: T[];
+  /** Cursor for the next page, or null when the scan is exhausted. */
+  continueCursor: string | null;
+  isDone: boolean;
+}
+
+/**
+ * Select a page from a descending, cursor-bounded scan window.
+ *
+ * `docs` is the raw scan (already range-bounded by the caller); `matches`
+ * filters it (e.g. top-level only, followed authors only). The continue
+ * cursor points at the last *returned* item when the page fills, or at the
+ * last *scanned* document when the window was capped before filling — so the
+ * next page resumes exactly where this scan stopped, never skipping rows.
+ *
+ * `scanExhausted` must be true when `docs` reached the end of the index
+ * (i.e. the query returned fewer rows than requested).
+ */
+export function selectFeedPage<T extends CursorablePosition>(
+  docs: T[],
+  matches: (doc: T) => boolean,
+  pageSize: number,
+  scanExhausted: boolean
+): PageSelection<T> {
+  const items: T[] = [];
+
+  for (const doc of docs) {
+    if (!matches(doc)) continue;
+    items.push(doc);
+    if (items.length === pageSize) {
+      return {
+        items,
+        continueCursor: encodeFeedCursor({ t: doc.createdAt, ct: doc._creationTime }),
+        isDone: false,
+      };
+    }
+  }
+
+  if (scanExhausted || docs.length === 0) {
+    return { items, continueCursor: null, isDone: true };
+  }
+
+  const lastScanned = docs[docs.length - 1];
+  return {
+    items,
+    continueCursor: encodeFeedCursor({
+      t: lastScanned.createdAt,
+      ct: lastScanned._creationTime,
+    }),
+    isDone: false,
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -66,6 +66,7 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_author", ["authorId"])
+    .index("by_author_and_created", ["authorId", "createdAt"])
     .index("by_created", ["createdAt"])
     .index("by_parent_chronicle", ["parentChronicleId"])
     .index("by_parent_and_created", ["parentChronicleId", "createdAt"]),

--- a/src/components/social/ChronicleCard.tsx
+++ b/src/components/social/ChronicleCard.tsx
@@ -31,6 +31,8 @@ interface ChronicleCardProps {
   onAvatarClick: (userId: string) => void;
   onBookmark: (id: string) => void;
   onDelete?: (id: string) => void;
+  /** Lets the feed lazily fetch reply threads only for expanded cards. */
+  onRepliesToggle?: (chronicleId: string, expanded: boolean) => void;
 }
 
 export function ChronicleCard({
@@ -43,6 +45,7 @@ export function ChronicleCard({
   onAvatarClick,
   onBookmark,
   onDelete,
+  onRepliesToggle,
 }: ChronicleCardProps) {
   const [showReplies, setShowReplies] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -131,7 +134,11 @@ export function ChronicleCard({
             isBookmarked={chronicle.isBookmarked}
             onLike={() => onLike(chronicle.id)}
             onRepost={() => onRepost(chronicle.id)}
-            onReplyToggle={() => setShowReplies((s) => !s)}
+            onReplyToggle={() => {
+              const next = !showReplies;
+              setShowReplies(next);
+              onRepliesToggle?.(chronicle.id, next);
+            }}
             onBookmark={() => onBookmark(chronicle.id)}
           />
         </div>

--- a/src/components/social/FeedTimeline.tsx
+++ b/src/components/social/FeedTimeline.tsx
@@ -12,6 +12,10 @@ interface FeedTimelineProps {
   onAvatarClick: (userId: string) => void;
   onBookmark: (id: string) => void;
   onDelete: (id: string) => void;
+  onRepliesToggle?: (chronicleId: string, expanded: boolean) => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
 export function FeedTimeline({
@@ -25,6 +29,10 @@ export function FeedTimeline({
   onAvatarClick,
   onBookmark,
   onDelete,
+  onRepliesToggle,
+  hasMore,
+  loadingMore,
+  onLoadMore,
 }: FeedTimelineProps) {
   if (chronicles.length === 0) {
     return (
@@ -50,8 +58,20 @@ export function FeedTimeline({
           onAvatarClick={onAvatarClick}
           onBookmark={onBookmark}
           onDelete={onDelete}
+          onRepliesToggle={onRepliesToggle}
         />
       ))}
+      {hasMore && onLoadMore && (
+        <div className="flex justify-center py-4">
+          <button
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="px-5 py-2 rounded-full text-sm font-medium text-accent hover:bg-accent/10 disabled:opacity-50 transition-colors"
+          >
+            {loadingMore ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/hooks/useChronicles.ts
+++ b/src/hooks/useChronicles.ts
@@ -33,6 +33,11 @@ export interface ChroniclesHook {
   bookmarkChronicle: (id: string) => void;
   deleteChronicle: (id: string) => void;
   addReply: (chronicleId: string, text: string) => Reply;
+  // Cursor pagination + lazy reply hydration (Convex-backed feeds only).
+  loadMore?: (numItems: number) => void;
+  canLoadMore?: boolean;
+  isLoadingMore?: boolean;
+  setRepliesExpanded?: (chronicleId: string, expanded: boolean) => void;
 }
 
 function loadChronicles(): Chronicle[] {

--- a/src/hooks/useConvexChronicles.ts
+++ b/src/hooks/useConvexChronicles.ts
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useAuth, useClerk } from "@clerk/clerk-react";
-import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { useConvexAuth, useMutation, usePaginatedQuery, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import type { Reply } from "@/types/social";
@@ -28,10 +28,22 @@ interface UseConvexChroniclesOptions {
   authorId?: string | null;
 }
 
-const FEED_LIMIT = 50;
-const RANKING_REFRESH_MS = 60_000;
-const EMPTY_CHRONICLES: ChronicleDocLike[] = [];
+const PAGE_SIZE = 20;
 const EMPTY_AUTHORS: AuthorRecord[] = [];
+const MAX_EXPANDED_PARENTS = 25;
+
+interface FeedPageDoc extends ChronicleDocLike {
+  authorId: string;
+  author: AuthorRecord | null;
+  viewer: ReactionState | null;
+}
+
+const AUTH_REQUIRED_FEEDS: ReadonlySet<FeedType> = new Set([
+  "following",
+  "bookmarks",
+  "likes",
+  "reposts",
+]);
 
 export function useConvexChronicles(
   feedType: FeedType = "forYou",
@@ -43,89 +55,59 @@ export function useConvexChronicles(
   const currentUserId = resolveCurrentUserId(userId);
 
   const [localReplies, setLocalReplies] = useState<Record<string, Reply[]>>({});
-  const [nowBucketMs, setNowBucketMs] = useState(() => Math.floor(Date.now() / 60_000) * 60_000);
+  // Reply docs are fetched lazily, only for chronicles the user has expanded.
+  const [expandedIds, setExpandedIds] = useState<string[]>([]);
 
-  useEffect(() => {
-    const interval = window.setInterval(() => {
-      setNowBucketMs(Math.floor(Date.now() / 60_000) * 60_000);
-    }, RANKING_REFRESH_MS);
+  // Frozen per mount: the ranking time bucket. Engagement counts still update
+  // live; the decay reference refreshes on remount or feed switch. A ticking
+  // value here would reset the whole pagination stack every minute.
+  const [nowBucketMs] = useState(() => Math.floor(Date.now() / 60_000) * 60_000);
 
-    return () => window.clearInterval(interval);
-  }, []);
+  const skipFeed =
+    (AUTH_REQUIRED_FEEDS.has(feedType) && !isAuthenticated) ||
+    (feedType === "author" && !options?.authorId);
 
-  const forYouChronicles = useQuery(
-    api.chronicles.listForYou,
-    feedType === "forYou" ? { limit: FEED_LIMIT, nowBucketMs } : "skip"
+  const {
+    results: pageDocs,
+    status: feedStatus,
+    loadMore,
+  } = usePaginatedQuery(
+    api.chronicles.feedPage,
+    skipFeed
+      ? "skip"
+      : {
+          feed: feedType,
+          authorId: feedType === "author" ? options?.authorId ?? undefined : undefined,
+          nowBucketMs: feedType === "forYou" ? nowBucketMs : undefined,
+        },
+    { initialNumItems: PAGE_SIZE }
   );
-  const followingChronicles = useQuery(
-    api.chronicles.listFollowing,
-    feedType === "following" && isAuthenticated ? { limit: FEED_LIMIT } : "skip"
-  );
-  const authorChronicles = useQuery(
-    api.chronicles.listByAuthor,
-    feedType === "author" && options?.authorId ? { authorId: options.authorId, limit: FEED_LIMIT } : "skip"
-  );
-  const bookmarkedChronicles = useQuery(
-    api.chronicles.listBookmarked,
-    feedType === "bookmarks" && isAuthenticated ? { limit: FEED_LIMIT } : "skip"
-  );
-  const likedChronicles = useQuery(
-    api.chronicles.listLiked,
-    feedType === "likes" && isAuthenticated ? { limit: FEED_LIMIT } : "skip"
-  );
-  const repostedChronicles = useQuery(
-    api.chronicles.listReposted,
-    feedType === "reposts" && isAuthenticated ? { limit: FEED_LIMIT } : "skip"
-  );
-
-  const rawChroniclesResult = useMemo(() => {
-    if (feedType === "following") return followingChronicles;
-    if (feedType === "author") return authorChronicles;
-    if (feedType === "bookmarks") return bookmarkedChronicles;
-    if (feedType === "likes") return likedChronicles;
-    if (feedType === "reposts") return repostedChronicles;
-    return forYouChronicles;
-  }, [
-    authorChronicles,
-    bookmarkedChronicles,
-    feedType,
-    followingChronicles,
-    forYouChronicles,
-    likedChronicles,
-    repostedChronicles,
-  ]) as ChronicleDocLike[] | undefined;
-  const rawChronicles = rawChroniclesResult ?? EMPTY_CHRONICLES;
-
-  const chronicleIds = useMemo(
-    () => rawChronicles.map((chronicle) => chronicle._id as Id<"chronicles">),
-    [rawChronicles]
-  );
-
-  const reactionStates = useQuery(
-    api.chronicles.userReactionStates,
-    chronicleIds.length > 0 && isAuthenticated ? { chronicleIds } : "skip"
-  ) as Record<string, ReactionState> | undefined;
-
-  const authorIds = useMemo(
-    () => [...new Set(rawChronicles.map((chronicle) => chronicle.authorId))],
-    [rawChronicles]
-  );
-
-  const authorsResult = useQuery(
-    api.users.getBatch,
-    authorIds.length > 0 ? { clerkIds: authorIds } : "skip"
-  ) as AuthorRecord[] | undefined;
-  const authors = authorsResult ?? EMPTY_AUTHORS;
+  // usePaginatedQuery always returns an array (empty while loading/skipped).
+  const rawChronicles = pageDocs as FeedPageDoc[];
 
   const me = useQuery(api.users.getMe, isAuthenticated ? {} : "skip") as
     | (AuthorRecord & { handle?: string })
     | null
     | undefined;
 
+  // Lazy replies: only chronicles the user expanded, capped well below the
+  // server batch limit. Visible chronicle ids gate against stale expansions.
+  const visibleIds = useMemo(
+    () => new Set(rawChronicles.map((chronicle) => chronicle._id)),
+    [rawChronicles]
+  );
+  const expandedVisibleIds = useMemo(
+    () =>
+      expandedIds
+        .filter((id) => visibleIds.has(id))
+        .slice(-MAX_EXPANDED_PARENTS) as Id<"chronicles">[],
+    [expandedIds, visibleIds]
+  );
+
   const replyDocMap = useQuery(
     api.chronicles.listRepliesBatch,
-    chronicleIds.length > 0
-      ? { parentIds: chronicleIds, limitPerParent: 30 }
+    expandedVisibleIds.length > 0
+      ? { parentIds: expandedVisibleIds, limitPerParent: 30 }
       : "skip"
   ) as Record<string, ReplyDocLike[]> | undefined;
 
@@ -153,23 +135,23 @@ export function useConvexChronicles(
   const removeMutation = useMutation(api.chronicles.remove);
   const replyMutation = useMutation(api.chronicles.addReply);
 
-  const authorById = useMemo(() => {
-    const allAuthors = [...authors, ...replyAuthors];
-    return new Map(allAuthors.map((author) => [author.clerkId, author]));
-  }, [authors, replyAuthors]);
+  const replyAuthorById = useMemo(
+    () => new Map(replyAuthors.map((author) => [author.clerkId, author])),
+    [replyAuthors]
+  );
 
   const chronicles = useMemo(
     () =>
       rawChronicles.map((doc) =>
         enrichFeedChronicle({
           doc,
-          reactionState: reactionStates?.[doc._id],
-          author: authorById.get(doc.authorId),
+          reactionState: doc.viewer ?? undefined,
+          author: doc.author ?? undefined,
           fallbackAuthorName: doc.authorId === currentUserId ? me?.name ?? "You" : "Reader",
           fallbackAuthorHandle: doc.authorId === currentUserId ? me?.handle ?? "you" : "reader",
         })
       ),
-    [authorById, currentUserId, me?.handle, me?.name, rawChronicles, reactionStates]
+    [currentUserId, me?.handle, me?.name, rawChronicles]
   );
 
   const serverReplies = useMemo(() => {
@@ -178,7 +160,7 @@ export function useConvexChronicles(
       Object.entries(replyDocMap).map(([parentId, replies]) => [
         parentId,
         mapReplyDocs(replies).map((reply) => {
-          const author = authorById.get(reply.authorId);
+          const author = replyAuthorById.get(reply.authorId);
           const isCurrentUserReply = reply.authorId === currentUserId;
           return {
             ...reply,
@@ -191,7 +173,7 @@ export function useConvexChronicles(
         }),
       ])
     );
-  }, [authorById, currentUserId, me?.handle, me?.name, replyDocMap]);
+  }, [currentUserId, me?.handle, me?.name, replyAuthorById, replyDocMap]);
 
   const mergedReplies = useMemo(
     () => mergeReplyMaps(serverReplies, localReplies),
@@ -218,6 +200,17 @@ export function useConvexChronicles(
   return {
     chronicles,
     replies: mergedReplies,
+
+    loadMore: (numItems: number) => loadMore(numItems || PAGE_SIZE),
+    canLoadMore: feedStatus === "CanLoadMore",
+    isLoadingMore: feedStatus === "LoadingMore",
+
+    setRepliesExpanded: (chronicleId: string, expanded: boolean) => {
+      setExpandedIds((prev) => {
+        const without = prev.filter((id) => id !== chronicleId);
+        return expanded ? [...without, chronicleId] : without;
+      });
+    },
 
     addChronicle: (draft: NewChronicleDraft) => {
       if (!ensureAuthenticatedForWrite()) return;

--- a/src/pages/Feed.tsx
+++ b/src/pages/Feed.tsx
@@ -108,6 +108,10 @@ export default function Feed() {
     bookmarkChronicle,
     deleteChronicle,
     addReply,
+    loadMore,
+    canLoadMore,
+    isLoadingMore,
+    setRepliesExpanded,
   } = useChronicles(chroniclesFeedType, {
     authorId: routeProfileUserId ?? null,
   });
@@ -346,6 +350,10 @@ export default function Feed() {
           onAvatarClick={handleAvatarClick}
           onBookmark={bookmarkChronicle}
           onDelete={deleteChronicle}
+          onRepliesToggle={setRepliesExpanded}
+          hasMore={canLoadMore}
+          loadingMore={isLoadingMore}
+          onLoadMore={loadMore ? () => loadMore(20) : undefined}
         />
       </SocialLayout>
 

--- a/tests/feedPagination.test.ts
+++ b/tests/feedPagination.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeFeedCursor,
+  encodeFeedCursor,
+  isAfterCursor,
+  selectFeedPage,
+} from "../convex/lib/feedPagination";
+
+const doc = (createdAt: number, creationTime = createdAt, extra = {}) => ({
+  createdAt,
+  _creationTime: creationTime,
+  ...extra,
+});
+
+describe("feed cursor encoding", () => {
+  it("round-trips a cursor", () => {
+    const cursor = { t: 1700000000000, ct: 1700000000000.5 };
+    expect(decodeFeedCursor(encodeFeedCursor(cursor))).toEqual(cursor);
+  });
+
+  it("returns null for malformed input", () => {
+    expect(decodeFeedCursor(null)).toBeNull();
+    expect(decodeFeedCursor("")).toBeNull();
+    expect(decodeFeedCursor("not json")).toBeNull();
+    expect(decodeFeedCursor('{"t":"nope"}')).toBeNull();
+  });
+});
+
+describe("isAfterCursor", () => {
+  const cursor = { t: 1000, ct: 1000.5 };
+
+  it("accepts strictly older documents", () => {
+    expect(isAfterCursor(doc(999), cursor)).toBe(true);
+  });
+
+  it("rejects newer documents and the cursor document itself", () => {
+    expect(isAfterCursor(doc(1001), cursor)).toBe(false);
+    expect(isAfterCursor(doc(1000, 1000.5), cursor)).toBe(false);
+  });
+
+  it("breaks same-millisecond ties on _creationTime", () => {
+    expect(isAfterCursor(doc(1000, 1000.2), cursor)).toBe(true);
+    expect(isAfterCursor(doc(1000, 1000.9), cursor)).toBe(false);
+  });
+});
+
+describe("selectFeedPage", () => {
+  const docsDesc = [doc(50), doc(40), doc(30), doc(20), doc(10)];
+
+  it("fills a page and points the cursor at the last returned item", () => {
+    const page = selectFeedPage(docsDesc, () => true, 3, false);
+    expect(page.items.map((d) => d.createdAt)).toEqual([50, 40, 30]);
+    expect(page.isDone).toBe(false);
+    expect(decodeFeedCursor(page.continueCursor)).toEqual({ t: 30, ct: 30 });
+  });
+
+  it("resuming from the cursor yields the next disjoint page (no dupes, no gaps)", () => {
+    const first = selectFeedPage(docsDesc, () => true, 3, false);
+    const cursor = decodeFeedCursor(first.continueCursor)!;
+    const remaining = docsDesc.filter((d) => isAfterCursor(d, cursor));
+    const second = selectFeedPage(remaining, () => true, 3, true);
+    expect(second.items.map((d) => d.createdAt)).toEqual([20, 10]);
+    expect(second.isDone).toBe(true);
+    const seen = [...first.items, ...second.items].map((d) => d.createdAt);
+    expect(new Set(seen).size).toBe(docsDesc.length);
+  });
+
+  it("returns a short page with a resume cursor when the scan window caps out", () => {
+    const page = selectFeedPage(docsDesc, (d) => d.createdAt === 10, 3, false);
+    expect(page.items.map((d) => d.createdAt)).toEqual([10]);
+    expect(page.isDone).toBe(false);
+    expect(decodeFeedCursor(page.continueCursor)).toEqual({ t: 10, ct: 10 });
+  });
+
+  it("marks done when the scan exhausted the index", () => {
+    const page = selectFeedPage(docsDesc, (d) => d.createdAt > 30, 10, true);
+    expect(page.items.map((d) => d.createdAt)).toEqual([50, 40]);
+    expect(page.isDone).toBe(true);
+    expect(page.continueCursor).toBeNull();
+  });
+
+  it("handles an empty scan window", () => {
+    const page = selectFeedPage([], () => true, 5, true);
+    expect(page.items).toEqual([]);
+    expect(page.isDone).toBe(true);
+  });
+
+  it("keeps same-millisecond documents across a page boundary", () => {
+    const tied = [doc(100, 100.9), doc(100, 100.5), doc(100, 100.1)];
+    const first = selectFeedPage(tied, () => true, 2, false);
+    const cursor = decodeFeedCursor(first.continueCursor)!;
+    const remaining = tied.filter((d) => isAfterCursor(d, cursor));
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]._creationTime).toBe(100.1);
+  });
+});


### PR DESCRIPTION
Implements Scalability Phase 1 (#27): feed read cost is now a fixed upper bound per page instead of scaling with content and table size.

## What changed

**One hydrated query per page.** New `chronicles.feedPage` serves all six feed variants (forYou / following / author / bookmarks / likes / reposts) and returns each chronicle with its author record and the viewer's reaction states attached. The client previously ran **five subscriptions per feed render** (feed + reaction states + author batch + eager reply batch + reply-author batch); it now runs **one** (plus `getMe` once per session).

**Cursor pagination, airtight contract.** Cursors encode `(createdAt, _creationTime)` of the last returned item; pages resume with an inclusive index range plus a strict after-cursor filter, so concurrent inserts can't cause duplicates or gaps. Pure helpers in `convex/lib/feedPagination.ts` with 11 unit tests (round-trip, malformed cursors, same-millisecond ties across page boundaries, short-page resume).

**For You = ranked chronological windows.** Each page is the next chronological slice, reordered by the existing engagement ranking *within* the window. Deliberate behavior change from the legacy ranked-pool: the old approach permanently dropped candidates that didn't make the top of the pool; windows give full timeline coverage while keeping the discovery feel. The ranking time bucket is frozen per mount so the pagination stack doesn't reset every 60s.

**Bounded scans.** Following scans ≤400 index rows/page (follow list capped at 500 as before), author ≤300, reaction feeds pageSize+20 rows plus one point lookup per row. Hydration adds ≤1 user lookup per distinct author and 3 point lookups per item. Telemetry: each call logs feed/returned/cursor/done to the Convex dashboard next to execution time.

**Lazy replies.** Reply threads now load only for chronicles the user actually expands (tracked via a new `onRepliesToggle` path through FeedTimeline/ChronicleCard). Previously every feed render prefetched up to 30 replies × 50 parents (~1,500 docs) for collapsed cards.

**Index fix found by testing.** The author feed originally scanned `by_author` (ordered by `_creationTime`) with a `createdAt` cursor — seeding 45 docs in one transaction (near-identical creation times) exposed duplicates + early termination. Added `by_author_and_created` so scan order matches cursor order; reaction feeds now cursor on `_creationTime` to match their index.

**Compatibility.** Legacy list queries are retained (deprecated) so the currently-deployed frontend keeps working; they can be deleted after the next production deploy (#30).

## Verification

Against a seeded dev deployment (45 chronicles, 3 authors, 3 replies):
- forYou walk: 20 + 20 + 5 items, **45/45 unique ids**, `isDone` correct, authors hydrated on every item.
- author walk: 10 + 5, 15/15 unique, replies excluded.
- Browser: feed renders 20 cards → Load more → 40 → 45 → button disappears at `isDone`.
- Lazy replies: reply text absent from DOM until expand; all 3 appear on expand.
- Seed data cleaned up after testing (`devSeed:cleanup`, internal-only mutations kept for future use).

`eslint` 0 errors, `tsc -b` clean, **70/70 tests**, production build passes.

Closes #27

Generated with [Claude Code](https://claude.com/claude-code)
