### PR TITLE
fix(convex): server-side content limits + bookmark existence check (closes #29)

### DIFF
--- a/convex/chronicles.ts
+++ b/convex/chronicles.ts
@@ -18,6 +18,7 @@ import {
   SAME_TS_BUFFER,
   type FeedCursor,
 } from "./lib/feedPagination";
+import { assertChronicleContent } from "./lib/contentLimits";
 
 const LIST_DEFAULT_LIMIT = 20;
 const FEED_DEFAULT_LIMIT = 40;
@@ -710,6 +711,7 @@ export const create = mutation({
   },
   handler: async (ctx, args) => {
     const userId = await requireAuthenticatedUserId(ctx);
+    assertChronicleContent(args);
     return ctx.db.insert("chronicles", {
       authorId: userId,
       text: args.text,
@@ -799,9 +801,14 @@ export const bookmark = mutation({
 
     if (existing) {
       await ctx.db.delete(existing._id);
-    } else {
-      await ctx.db.insert("bookmarks", { userId, chronicleId, createdAt: Date.now() });
+      return;
     }
+
+    // Match like/repost: never bookmark a deleted or nonexistent chronicle.
+    const chronicle = await ctx.db.get(chronicleId);
+    if (!chronicle) return;
+
+    await ctx.db.insert("bookmarks", { userId, chronicleId, createdAt: Date.now() });
   },
 });
 
@@ -847,6 +854,7 @@ export const addReply = mutation({
   },
   handler: async (ctx, { parentChronicleId, text }) => {
     const userId = await requireAuthenticatedUserId(ctx);
+    assertChronicleContent({ text });
 
     // Validate parent exists before inserting to avoid orphaned replies.
     const parent = await ctx.db.get(parentChronicleId);

--- a/convex/lib/contentLimits.ts
+++ b/convex/lib/contentLimits.ts
@@ -1,0 +1,35 @@
+/**
+ * Server-side content limits for Chronicles. The UI enforces the same caps,
+ * but direct API calls must not be able to bypass them.
+ */
+
+export const CHRONICLE_TEXT_MAX = 500;
+export const HIGHLIGHT_TEXT_MAX = 2000;
+export const BOOK_TITLE_MAX = 300;
+
+export class ContentLimitError extends Error {
+  constructor(field: string, max: number, actual: number) {
+    super(`${field} exceeds the maximum length of ${max} characters (got ${actual}).`);
+    this.name = "ContentLimitError";
+  }
+}
+
+export function assertWithinLimit(
+  field: string,
+  value: string | undefined,
+  max: number
+): void {
+  if (value !== undefined && value.length > max) {
+    throw new ContentLimitError(field, max, value.length);
+  }
+}
+
+export function assertChronicleContent(args: {
+  text: string;
+  highlightText?: string;
+  bookTitle?: string;
+}): void {
+  assertWithinLimit("text", args.text, CHRONICLE_TEXT_MAX);
+  assertWithinLimit("highlightText", args.highlightText, HIGHLIGHT_TEXT_MAX);
+  assertWithinLimit("bookTitle", args.bookTitle, BOOK_TITLE_MAX);
+}

--- a/tests/contentLimits.test.ts
+++ b/tests/contentLimits.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertChronicleContent,
+  assertWithinLimit,
+  CHRONICLE_TEXT_MAX,
+  ContentLimitError,
+  HIGHLIGHT_TEXT_MAX,
+} from "../convex/lib/contentLimits";
+
+describe("assertWithinLimit", () => {
+  it("accepts values at or below the limit", () => {
+    expect(() => assertWithinLimit("text", "a".repeat(10), 10)).not.toThrow();
+    expect(() => assertWithinLimit("text", "", 10)).not.toThrow();
+    expect(() => assertWithinLimit("text", undefined, 10)).not.toThrow();
+  });
+
+  it("rejects values over the limit with a descriptive error", () => {
+    expect(() => assertWithinLimit("text", "a".repeat(11), 10)).toThrow(ContentLimitError);
+    expect(() => assertWithinLimit("text", "a".repeat(11), 10)).toThrow(/maximum length of 10/);
+  });
+});
+
+describe("assertChronicleContent", () => {
+  it("accepts a maximal valid chronicle", () => {
+    expect(() =>
+      assertChronicleContent({
+        text: "a".repeat(CHRONICLE_TEXT_MAX),
+        highlightText: "b".repeat(HIGHLIGHT_TEXT_MAX),
+        bookTitle: "A Book",
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects oversized text", () => {
+    expect(() =>
+      assertChronicleContent({ text: "a".repeat(CHRONICLE_TEXT_MAX + 1) })
+    ).toThrow(ContentLimitError);
+  });
+
+  it("rejects oversized highlight text", () => {
+    expect(() =>
+      assertChronicleContent({ text: "ok", highlightText: "h".repeat(HIGHLIGHT_TEXT_MAX + 1) })
+    ).toThrow(ContentLimitError);
+  });
+});


### PR DESCRIPTION
Two hardening gaps from CONVEX_CHRONICLES_REVIEW.md:

1. `chronicles.create` / `addReply` accepted unbounded strings — the 500-char cap only lived in the UI. Limits now enforced server-side via `convex/lib/contentLimits.ts` (text 500, highlightText 2000, bookTitle 300) with unit tests.
2. `bookmark` could insert rows pointing at deleted/nonexistent chronicles; it now checks existence first, consistent with `like`/`repost`. Removing an existing bookmark still works after the chronicle is gone.

eslint 0 errors, tsc clean, 75/75 tests.

Closes #29

Generated with [Claude Code](https://claude.com/claude-code)