### PR TITLE
feat(feed): server-side spoiler filtering gated on reading progress (closes #31)

### DIFF
--- a/convex/chronicles.ts
+++ b/convex/chronicles.ts
@@ -19,6 +19,7 @@ import {
   type FeedCursor,
 } from "./lib/feedPagination";
 import { assertChronicleContent } from "./lib/contentLimits";
+import { isSpoilerGated, redactSpoilerContent, shouldRevealSpoiler } from "./lib/spoilers";
 
 const LIST_DEFAULT_LIMIT = 20;
 const FEED_DEFAULT_LIMIT = 40;
@@ -426,7 +427,8 @@ interface ViewerReactionState {
   isBookmarked: boolean;
 }
 
-interface FeedPageItem extends Doc<"chronicles"> {
+interface FeedPageItem extends Omit<Doc<"chronicles">, "highlightText"> {
+  highlightText?: string;
   author: {
     clerkId: string;
     name?: string;
@@ -434,6 +436,8 @@ interface FeedPageItem extends Doc<"chronicles"> {
     avatarUrl?: string;
   } | null;
   viewer: ViewerReactionState | null;
+  /** True when spoiler content was stripped server-side for this viewer. */
+  spoilerRedacted?: boolean;
 }
 
 /**
@@ -462,6 +466,29 @@ async function hydrateFeedPage(
 
   const identity = await ctx.auth.getUserIdentity();
   const viewerId = identity?.subject ?? null;
+
+  // Spoiler gating: one progress lookup per distinct gated book, viewer-side.
+  const gatedBookRefs = [
+    ...new Set(
+      chronicles
+        .filter((chronicle) => isSpoilerGated(chronicle))
+        .map((chronicle) => chronicle.bookRef!)
+    ),
+  ];
+  const viewerProgressByBook = new Map<string, number>();
+  if (viewerId && gatedBookRefs.length > 0) {
+    await Promise.all(
+      gatedBookRefs.map(async (bookHash) => {
+        const progress = await ctx.db
+          .query("readingProgress")
+          .withIndex("by_user_and_book", (q) =>
+            q.eq("userId", viewerId).eq("bookHash", bookHash)
+          )
+          .unique();
+        if (progress) viewerProgressByBook.set(bookHash, progress.percentage);
+      })
+    );
+  }
 
   const viewerStates = viewerId
     ? await Promise.all(
@@ -497,8 +524,16 @@ async function hydrateFeedPage(
 
   return chronicles.map((chronicle, index) => {
     const author = authorByClerkId.get(chronicle.authorId);
+    const reveal = shouldRevealSpoiler(
+      chronicle,
+      viewerId,
+      chronicle.bookRef != null
+        ? viewerProgressByBook.get(chronicle.bookRef) ?? null
+        : null
+    );
+    const content = reveal ? chronicle : redactSpoilerContent(chronicle);
     return {
-      ...chronicle,
+      ...content,
       author: author
         ? {
             clerkId: author.clerkId,
@@ -712,6 +747,20 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuthenticatedUserId(ctx);
     assertChronicleContent(args);
+
+    // Capture the author's position at post time so the feed can gate
+    // spoiler content on it (lib/spoilers.ts).
+    let spoilerProgress: number | undefined;
+    if (args.spoilerTag && args.bookRef) {
+      const authorProgress = await ctx.db
+        .query("readingProgress")
+        .withIndex("by_user_and_book", (q) =>
+          q.eq("userId", userId).eq("bookHash", args.bookRef!)
+        )
+        .unique();
+      spoilerProgress = authorProgress?.percentage ?? 0;
+    }
+
     return ctx.db.insert("chronicles", {
       authorId: userId,
       text: args.text,
@@ -719,6 +768,7 @@ export const create = mutation({
       bookTitle: args.bookTitle,
       bookRef: args.bookRef,
       spoilerTag: args.spoilerTag,
+      spoilerProgress,
       likeCount: 0,
       replyCount: 0,
       repostCount: 0,

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -67,6 +67,40 @@ export const seed = internalMutation({
   },
 });
 
+export const seedSpoiler = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const clerkId = `${SEED_AUTHOR_PREFIX}0`;
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", clerkId))
+      .unique();
+    if (!existing) {
+      await ctx.db.insert("users", {
+        clerkId,
+        email: `${clerkId}@example.test`,
+        name: "Seed Reader 1",
+        handle: "seedreader1",
+        searchText: "seed reader 1 seedreader1",
+      });
+    }
+    const id = await ctx.db.insert("chronicles", {
+      authorId: clerkId,
+      text: "[seed] the butler did it",
+      highlightText: "[seed] shocking quote",
+      bookTitle: "Seed Mystery",
+      bookRef: "seed-book-hash",
+      spoilerTag: true,
+      spoilerProgress: 0.5,
+      likeCount: 0,
+      replyCount: 0,
+      repostCount: 0,
+      createdAt: Date.now(),
+    });
+    return { id };
+  },
+});
+
 export const cleanup = internalMutation({
   args: {},
   handler: async (ctx) => {

--- a/convex/lib/spoilers.ts
+++ b/convex/lib/spoilers.ts
@@ -1,0 +1,47 @@
+/**
+ * Server-side spoiler gating (issue #31).
+ *
+ * Rule: a spoiler-tagged chronicle that references a book is hidden until the
+ * viewer has a reading-progress record for that book at or beyond the
+ * poster's position when they posted. The author always sees their own
+ * content; signed-out viewers and non-readers of the book see a redacted
+ * card. Spoiler text never leaves the server for gated viewers.
+ *
+ * Spoiler-tagged chronicles without a book reference have no objective
+ * unlock criterion, so they keep the client-side badge treatment.
+ */
+
+export interface SpoilerGateFields {
+  authorId: string;
+  spoilerTag?: boolean;
+  bookRef?: string;
+  /** Author's reading percentage (0..1) for bookRef at post time. */
+  spoilerProgress?: number;
+}
+
+export function isSpoilerGated(doc: SpoilerGateFields): boolean {
+  return doc.spoilerTag === true && typeof doc.bookRef === "string" && doc.bookRef.length > 0;
+}
+
+export function shouldRevealSpoiler(
+  doc: SpoilerGateFields,
+  viewerId: string | null,
+  /** Viewer's percentage for doc.bookRef, or null when they have no record. */
+  viewerProgress: number | null
+): boolean {
+  if (!isSpoilerGated(doc)) return true;
+  if (viewerId !== null && viewerId === doc.authorId) return true;
+  if (viewerId === null || viewerProgress === null) return false;
+  return viewerProgress >= (doc.spoilerProgress ?? 0);
+}
+
+export function redactSpoilerContent<T extends SpoilerGateFields & { text: string; highlightText?: string }>(
+  doc: T
+): T & { spoilerRedacted: true } {
+  return {
+    ...doc,
+    text: "",
+    highlightText: undefined,
+    spoilerRedacted: true,
+  };
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -60,6 +60,9 @@ export default defineSchema({
     bookTitle: v.optional(v.string()),
     parentChronicleId: v.optional(v.id("chronicles")),
     spoilerTag: v.optional(v.boolean()),
+    // Author's reading percentage (0..1) for bookRef at post time; viewers
+    // below this position get the content redacted server-side.
+    spoilerProgress: v.optional(v.number()),
     likeCount: v.number(),
     replyCount: v.number(),
     repostCount: v.number(),

--- a/src/components/social/ChronicleCard.tsx
+++ b/src/components/social/ChronicleCard.tsx
@@ -98,6 +98,17 @@ export function ChronicleCard({
               </div>
             )}
           </div>
+          {chronicle.spoilerRedacted && (
+            <div className="mt-2 rounded-lg border border-dashed border-amber-500/40 bg-amber-500/5 px-3 py-2.5">
+              <p className="text-[13px] text-muted-foreground">
+                <span className="font-semibold uppercase tracking-wider text-[10px] text-amber-500/80 mr-2">
+                  Spoiler
+                </span>
+                Hidden until you reach this point
+                {chronicle.bookTitle ? ` in ${chronicle.bookTitle}` : ""}.
+              </p>
+            </div>
+          )}
           {chronicle.text && (
             <p className="text-[15px] leading-relaxed mt-1">{chronicle.text}</p>
           )}

--- a/src/lib/social/mapChronicles.ts
+++ b/src/lib/social/mapChronicles.ts
@@ -12,6 +12,7 @@ export interface ChronicleDocLike {
   bookTitle?: string;
   bookRef?: string;
   spoilerTag?: boolean;
+  spoilerRedacted?: boolean;
 }
 
 export function mapChronicleDocToFeedChronicle(doc: ChronicleDocLike): Chronicle {
@@ -30,5 +31,6 @@ export function mapChronicleDocToFeedChronicle(doc: ChronicleDocLike): Chronicle
     bookTitle: doc.bookTitle,
     bookHash: doc.bookRef,
     spoilerTag: doc.spoilerTag,
+    spoilerRedacted: doc.spoilerRedacted,
   };
 }

--- a/src/types/social.ts
+++ b/src/types/social.ts
@@ -24,6 +24,8 @@ export interface Chronicle {
   bookTitle?: string;
   bookHash?: string;
   spoilerTag?: boolean;
+  /** Content was stripped server-side; show a locked-spoiler placeholder. */
+  spoilerRedacted?: boolean;
 }
 
 export type FeedTab = "forYou" | "following";

--- a/tests/spoilers.test.ts
+++ b/tests/spoilers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSpoilerGated,
+  redactSpoilerContent,
+  shouldRevealSpoiler,
+} from "../convex/lib/spoilers";
+
+const gated = {
+  authorId: "author-1",
+  spoilerTag: true,
+  bookRef: "book-hash",
+  spoilerProgress: 0.6,
+  text: "Snape kills Dumbledore",
+  highlightText: "the quote",
+};
+
+describe("isSpoilerGated", () => {
+  it("requires both the spoiler tag and a book reference", () => {
+    expect(isSpoilerGated(gated)).toBe(true);
+    expect(isSpoilerGated({ ...gated, spoilerTag: false })).toBe(false);
+    expect(isSpoilerGated({ ...gated, spoilerTag: undefined })).toBe(false);
+    expect(isSpoilerGated({ ...gated, bookRef: undefined })).toBe(false);
+    expect(isSpoilerGated({ ...gated, bookRef: "" })).toBe(false);
+  });
+});
+
+describe("shouldRevealSpoiler", () => {
+  it("always reveals ungated content", () => {
+    expect(shouldRevealSpoiler({ ...gated, spoilerTag: false }, null, null)).toBe(true);
+  });
+
+  it("always reveals to the author", () => {
+    expect(shouldRevealSpoiler(gated, "author-1", null)).toBe(true);
+  });
+
+  it("hides from signed-out viewers", () => {
+    expect(shouldRevealSpoiler(gated, null, null)).toBe(false);
+  });
+
+  it("hides from viewers who have not started the book", () => {
+    expect(shouldRevealSpoiler(gated, "viewer-1", null)).toBe(false);
+  });
+
+  it("gates on the poster's position", () => {
+    expect(shouldRevealSpoiler(gated, "viewer-1", 0.59)).toBe(false);
+    expect(shouldRevealSpoiler(gated, "viewer-1", 0.6)).toBe(true);
+    expect(shouldRevealSpoiler(gated, "viewer-1", 1)).toBe(true);
+  });
+
+  it("treats a missing poster position as start-of-book (any reader unlocks)", () => {
+    const legacy = { ...gated, spoilerProgress: undefined };
+    expect(shouldRevealSpoiler(legacy, "viewer-1", 0)).toBe(true);
+    expect(shouldRevealSpoiler(legacy, "viewer-1", null)).toBe(false);
+  });
+});
+
+describe("redactSpoilerContent", () => {
+  it("strips text and highlight but keeps metadata", () => {
+    const redacted = redactSpoilerContent(gated);
+    expect(redacted.text).toBe("");
+    expect(redacted.highlightText).toBeUndefined();
+    expect(redacted.spoilerRedacted).toBe(true);
+    expect(redacted.bookRef).toBe("book-hash");
+    expect(redacted.spoilerTag).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements the architecture mandate from CLAUDE.md: spoiler content never ships to clients that should not see it.

How it works:
- `chronicles.create` captures the author's reading percentage for the referenced book at post time (`spoilerProgress`).
- `feedPage` hydration redacts `text`/`highlightText` server-side unless the viewer has a `readingProgress` record for that book at or beyond the poster's position (authors always see their own posts). Cost: one progress point-lookup per distinct gated book per page.
- Redacted items carry `spoilerRedacted: true`; `ChronicleCard` shows a locked placeholder: *Spoiler — hidden until you reach this point in {book}*.
- Spoiler posts without a book reference keep the current badge-only treatment — there is no objective unlock criterion for them.
- Legacy list queries (already deprecated, removal tracked with #30) are unchanged.

Verification: seeded a gated chronicle on the dev deployment and called `feedPage` anonymously — the response contained empty text, no highlight, `spoilerRedacted: true`, badge metadata intact (then cleaned up). Threshold/author/anon logic covered by 8 unit tests (83/83 passing). eslint 0 errors, tsc clean.

Stacked on #38 (both touch `chronicles.ts`) — merge #38 first; this PR retargets to main automatically when the base branch is deleted.

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)
